### PR TITLE
Updating OpenCR BSP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,4 @@ jobs:
             arduino-cli core install OpenCR:OpenCR -v
             arduino-cli core update-index
             arduino-cli lib update-index
-            # Remove when https://github.com/ROBOTIS-GIT/OpenCR/pull/253 merged
-            export ORIGIN=$(pwd)
-            cd /github/home/.arduino15/packages/OpenCR/hardware/OpenCR/1.4.15
-            rm -rf platform.txt
-            wget https://raw.githubusercontent.com/ROBOTIS-GIT/OpenCR/44bcd82f48a933a7db5fae1bd69e97cda4932832/arduino/opencr_arduino/opencr/platform.txt
-            cd $ORIGIN
-            # Remove until here
             arduino-cli compile --fqbn OpenCR:OpenCR:OpenCR /github/home/Arduino/libraries/micro_ros_arduino-0.0.1/examples/micro-ros_publisher -v

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ As the build process for ROS 2 and micro-ROS is based on custom meta-build syste
 
 Supported boards are:
 
-| Board                                                                    | State      | Details                                                                                             | Prebuild meta        |
-| ------------------------------------------------------------------------ | ---------- | --------------------------------------------------------------------------------------------------- | -------------------- |
-| [OpenCR](https://emanual.robotis.com/docs/en/parts/controller/opencr10/) | Supported  | [Based on custom board](https://emanual.robotis.com/docs/en/parts/controller/opencr10/#arduino-ide) | `colcon.meta`        |
-| [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)                   | Not tested | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon.meta`        |
-| [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)                   | Not tested | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon.meta`        |
-| [Teensy 3.2](https://www.pjrc.com/store/teensy32.html)                   | Not tested | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon_lowmem.meta` |
+| Board                                                                    | Min version | State      | Details                                                                                             | Prebuild meta        |
+| ------------------------------------------------------------------------ | ----------- | ---------- | --------------------------------------------------------------------------------------------------- | -------------------- |
+| [OpenCR](https://emanual.robotis.com/docs/en/parts/controller/opencr10/) | v1.4.16     | Supported  | [Based on custom board](https://emanual.robotis.com/docs/en/parts/controller/opencr10/#arduino-ide) | `colcon.meta`        |
+| [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)                   |             | Not tested | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon.meta`        |
+| [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)                   |             | Not tested | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon.meta`        |
+| [Teensy 3.2](https://www.pjrc.com/store/teensy32.html)                   |             | Not tested | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon_lowmem.meta` |
 
 You can find the available precompiled ROS 2 types for messages and services in [available_ros2_types](available_ros2_types).
 
@@ -59,15 +59,7 @@ see the file [3rd-party-licenses.txt](3rd-party-licenses.txt).
 
 - When using provided precompiled libraries, users should take into account the already configured static memory pools in middleware layers. [More info here](https://micro-ros.github.io/docs/tutorials/core/microxrcedds_rmw_configuration/).
 - micro-ROS transports should be refactored in order to provide a pluggable mechanims. Only USB serial transports are provided.
-- Both OpenCR and Teensyduino support files have to be patched in order to use precompiled libraries. 
-
-### Patch OpenCR
-
-```bash
-    cd ~/.arduino15/packages/OpenCR/hardware/OpenCR/1.4.15
-    rm -rf platform.txt
-    wget https://github.com/ROBOTIS-GIT/OpenCR/blob/develop/arduino/opencr_arduino/opencr/platform.txt
-```
+- Teensyduino support files have to be patched in order to use precompiled libraries. 
 
 ### Patch Teensyduino
 


### PR DESCRIPTION
This PR updates the requirement of having to patch the OpenCR Board support. Solved in https://github.com/ROBOTIS-GIT/OpenCR/pull/253 and released since v1.4.16