### PR TITLE
[fix] example_interfaces not found error

### DIFF
--- a/src/example_interfaces/action/detail/fibonacci__functions.h
+++ b/src/example_interfaces/action/detail/fibonacci__functions.h
@@ -1,0 +1,817 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:action/Fibonacci.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__ACTION__DETAIL__FIBONACCI__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__ACTION__DETAIL__FIBONACCI__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/action/detail/fibonacci__struct.h"
+
+/// Initialize action/Fibonacci message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__action__Fibonacci_Goal
+ * )) before or use
+ * example_interfaces__action__Fibonacci_Goal__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_Goal__init(example_interfaces__action__Fibonacci_Goal * msg);
+
+/// Finalize action/Fibonacci message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Goal__fini(example_interfaces__action__Fibonacci_Goal * msg);
+
+/// Create action/Fibonacci message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__action__Fibonacci_Goal__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_Goal *
+example_interfaces__action__Fibonacci_Goal__create();
+
+/// Destroy action/Fibonacci message.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_Goal__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Goal__destroy(example_interfaces__action__Fibonacci_Goal * msg);
+
+
+/// Initialize array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__action__Fibonacci_Goal__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_Goal__Sequence__init(example_interfaces__action__Fibonacci_Goal__Sequence * array, size_t size);
+
+/// Finalize array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_Goal__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Goal__Sequence__fini(example_interfaces__action__Fibonacci_Goal__Sequence * array);
+
+/// Create array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__action__Fibonacci_Goal__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_Goal__Sequence *
+example_interfaces__action__Fibonacci_Goal__Sequence__create(size_t size);
+
+/// Destroy array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_Goal__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Goal__Sequence__destroy(example_interfaces__action__Fibonacci_Goal__Sequence * array);
+
+/// Initialize action/Fibonacci message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__action__Fibonacci_Result
+ * )) before or use
+ * example_interfaces__action__Fibonacci_Result__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_Result__init(example_interfaces__action__Fibonacci_Result * msg);
+
+/// Finalize action/Fibonacci message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Result__fini(example_interfaces__action__Fibonacci_Result * msg);
+
+/// Create action/Fibonacci message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__action__Fibonacci_Result__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_Result *
+example_interfaces__action__Fibonacci_Result__create();
+
+/// Destroy action/Fibonacci message.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_Result__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Result__destroy(example_interfaces__action__Fibonacci_Result * msg);
+
+
+/// Initialize array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__action__Fibonacci_Result__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_Result__Sequence__init(example_interfaces__action__Fibonacci_Result__Sequence * array, size_t size);
+
+/// Finalize array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_Result__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Result__Sequence__fini(example_interfaces__action__Fibonacci_Result__Sequence * array);
+
+/// Create array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__action__Fibonacci_Result__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_Result__Sequence *
+example_interfaces__action__Fibonacci_Result__Sequence__create(size_t size);
+
+/// Destroy array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_Result__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Result__Sequence__destroy(example_interfaces__action__Fibonacci_Result__Sequence * array);
+
+/// Initialize action/Fibonacci message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__action__Fibonacci_Feedback
+ * )) before or use
+ * example_interfaces__action__Fibonacci_Feedback__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_Feedback__init(example_interfaces__action__Fibonacci_Feedback * msg);
+
+/// Finalize action/Fibonacci message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Feedback__fini(example_interfaces__action__Fibonacci_Feedback * msg);
+
+/// Create action/Fibonacci message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__action__Fibonacci_Feedback__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_Feedback *
+example_interfaces__action__Fibonacci_Feedback__create();
+
+/// Destroy action/Fibonacci message.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_Feedback__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Feedback__destroy(example_interfaces__action__Fibonacci_Feedback * msg);
+
+
+/// Initialize array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__action__Fibonacci_Feedback__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_Feedback__Sequence__init(example_interfaces__action__Fibonacci_Feedback__Sequence * array, size_t size);
+
+/// Finalize array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_Feedback__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Feedback__Sequence__fini(example_interfaces__action__Fibonacci_Feedback__Sequence * array);
+
+/// Create array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__action__Fibonacci_Feedback__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_Feedback__Sequence *
+example_interfaces__action__Fibonacci_Feedback__Sequence__create(size_t size);
+
+/// Destroy array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_Feedback__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_Feedback__Sequence__destroy(example_interfaces__action__Fibonacci_Feedback__Sequence * array);
+
+/// Initialize action/Fibonacci message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__action__Fibonacci_SendGoal_Request
+ * )) before or use
+ * example_interfaces__action__Fibonacci_SendGoal_Request__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_SendGoal_Request__init(example_interfaces__action__Fibonacci_SendGoal_Request * msg);
+
+/// Finalize action/Fibonacci message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_SendGoal_Request__fini(example_interfaces__action__Fibonacci_SendGoal_Request * msg);
+
+/// Create action/Fibonacci message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__action__Fibonacci_SendGoal_Request__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_SendGoal_Request *
+example_interfaces__action__Fibonacci_SendGoal_Request__create();
+
+/// Destroy action/Fibonacci message.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_SendGoal_Request__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_SendGoal_Request__destroy(example_interfaces__action__Fibonacci_SendGoal_Request * msg);
+
+
+/// Initialize array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__action__Fibonacci_SendGoal_Request__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__init(example_interfaces__action__Fibonacci_SendGoal_Request__Sequence * array, size_t size);
+
+/// Finalize array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_SendGoal_Request__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__fini(example_interfaces__action__Fibonacci_SendGoal_Request__Sequence * array);
+
+/// Create array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_SendGoal_Request__Sequence *
+example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__create(size_t size);
+
+/// Destroy array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_SendGoal_Request__Sequence__destroy(example_interfaces__action__Fibonacci_SendGoal_Request__Sequence * array);
+
+/// Initialize action/Fibonacci message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__action__Fibonacci_SendGoal_Response
+ * )) before or use
+ * example_interfaces__action__Fibonacci_SendGoal_Response__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_SendGoal_Response__init(example_interfaces__action__Fibonacci_SendGoal_Response * msg);
+
+/// Finalize action/Fibonacci message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_SendGoal_Response__fini(example_interfaces__action__Fibonacci_SendGoal_Response * msg);
+
+/// Create action/Fibonacci message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__action__Fibonacci_SendGoal_Response__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_SendGoal_Response *
+example_interfaces__action__Fibonacci_SendGoal_Response__create();
+
+/// Destroy action/Fibonacci message.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_SendGoal_Response__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_SendGoal_Response__destroy(example_interfaces__action__Fibonacci_SendGoal_Response * msg);
+
+
+/// Initialize array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__action__Fibonacci_SendGoal_Response__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__init(example_interfaces__action__Fibonacci_SendGoal_Response__Sequence * array, size_t size);
+
+/// Finalize array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_SendGoal_Response__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__fini(example_interfaces__action__Fibonacci_SendGoal_Response__Sequence * array);
+
+/// Create array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_SendGoal_Response__Sequence *
+example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__create(size_t size);
+
+/// Destroy array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_SendGoal_Response__Sequence__destroy(example_interfaces__action__Fibonacci_SendGoal_Response__Sequence * array);
+
+/// Initialize action/Fibonacci message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__action__Fibonacci_GetResult_Request
+ * )) before or use
+ * example_interfaces__action__Fibonacci_GetResult_Request__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_GetResult_Request__init(example_interfaces__action__Fibonacci_GetResult_Request * msg);
+
+/// Finalize action/Fibonacci message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_GetResult_Request__fini(example_interfaces__action__Fibonacci_GetResult_Request * msg);
+
+/// Create action/Fibonacci message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__action__Fibonacci_GetResult_Request__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_GetResult_Request *
+example_interfaces__action__Fibonacci_GetResult_Request__create();
+
+/// Destroy action/Fibonacci message.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_GetResult_Request__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_GetResult_Request__destroy(example_interfaces__action__Fibonacci_GetResult_Request * msg);
+
+
+/// Initialize array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__action__Fibonacci_GetResult_Request__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_GetResult_Request__Sequence__init(example_interfaces__action__Fibonacci_GetResult_Request__Sequence * array, size_t size);
+
+/// Finalize array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_GetResult_Request__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_GetResult_Request__Sequence__fini(example_interfaces__action__Fibonacci_GetResult_Request__Sequence * array);
+
+/// Create array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__action__Fibonacci_GetResult_Request__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_GetResult_Request__Sequence *
+example_interfaces__action__Fibonacci_GetResult_Request__Sequence__create(size_t size);
+
+/// Destroy array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_GetResult_Request__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_GetResult_Request__Sequence__destroy(example_interfaces__action__Fibonacci_GetResult_Request__Sequence * array);
+
+/// Initialize action/Fibonacci message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__action__Fibonacci_GetResult_Response
+ * )) before or use
+ * example_interfaces__action__Fibonacci_GetResult_Response__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_GetResult_Response__init(example_interfaces__action__Fibonacci_GetResult_Response * msg);
+
+/// Finalize action/Fibonacci message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_GetResult_Response__fini(example_interfaces__action__Fibonacci_GetResult_Response * msg);
+
+/// Create action/Fibonacci message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__action__Fibonacci_GetResult_Response__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_GetResult_Response *
+example_interfaces__action__Fibonacci_GetResult_Response__create();
+
+/// Destroy action/Fibonacci message.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_GetResult_Response__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_GetResult_Response__destroy(example_interfaces__action__Fibonacci_GetResult_Response * msg);
+
+
+/// Initialize array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__action__Fibonacci_GetResult_Response__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_GetResult_Response__Sequence__init(example_interfaces__action__Fibonacci_GetResult_Response__Sequence * array, size_t size);
+
+/// Finalize array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_GetResult_Response__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_GetResult_Response__Sequence__fini(example_interfaces__action__Fibonacci_GetResult_Response__Sequence * array);
+
+/// Create array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__action__Fibonacci_GetResult_Response__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_GetResult_Response__Sequence *
+example_interfaces__action__Fibonacci_GetResult_Response__Sequence__create(size_t size);
+
+/// Destroy array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_GetResult_Response__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_GetResult_Response__Sequence__destroy(example_interfaces__action__Fibonacci_GetResult_Response__Sequence * array);
+
+/// Initialize action/Fibonacci message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__action__Fibonacci_FeedbackMessage
+ * )) before or use
+ * example_interfaces__action__Fibonacci_FeedbackMessage__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_FeedbackMessage__init(example_interfaces__action__Fibonacci_FeedbackMessage * msg);
+
+/// Finalize action/Fibonacci message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_FeedbackMessage__fini(example_interfaces__action__Fibonacci_FeedbackMessage * msg);
+
+/// Create action/Fibonacci message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__action__Fibonacci_FeedbackMessage__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_FeedbackMessage *
+example_interfaces__action__Fibonacci_FeedbackMessage__create();
+
+/// Destroy action/Fibonacci message.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_FeedbackMessage__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_FeedbackMessage__destroy(example_interfaces__action__Fibonacci_FeedbackMessage * msg);
+
+
+/// Initialize array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__action__Fibonacci_FeedbackMessage__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__init(example_interfaces__action__Fibonacci_FeedbackMessage__Sequence * array, size_t size);
+
+/// Finalize array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_FeedbackMessage__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__fini(example_interfaces__action__Fibonacci_FeedbackMessage__Sequence * array);
+
+/// Create array of action/Fibonacci messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__action__Fibonacci_FeedbackMessage__Sequence *
+example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__create(size_t size);
+
+/// Destroy array of action/Fibonacci messages.
+/**
+ * It calls
+ * example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__action__Fibonacci_FeedbackMessage__Sequence__destroy(example_interfaces__action__Fibonacci_FeedbackMessage__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__ACTION__DETAIL__FIBONACCI__FUNCTIONS_H_

--- a/src/example_interfaces/action/detail/fibonacci__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/action/detail/fibonacci__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,337 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:action/Fibonacci.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__ACTION__FIBONACCI__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__ACTION__FIBONACCI__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__action__Fibonacci_Goal(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__action__Fibonacci_Goal(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_Goal)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__action__Fibonacci_Result(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__action__Fibonacci_Result(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_Result)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__action__Fibonacci_Feedback(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__action__Fibonacci_Feedback(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_Feedback)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__action__Fibonacci_SendGoal_Request(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__action__Fibonacci_SendGoal_Request(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_SendGoal_Request)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__action__Fibonacci_SendGoal_Response(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__action__Fibonacci_SendGoal_Response(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_SendGoal_Response)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#include "rosidl_runtime_c/service_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_SendGoal)();
+
+#ifdef __cplusplus
+}
+#endif
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__action__Fibonacci_GetResult_Request(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__action__Fibonacci_GetResult_Request(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_GetResult_Request)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__action__Fibonacci_GetResult_Response(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__action__Fibonacci_GetResult_Response(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_GetResult_Response)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+// already included above
+// #include "rosidl_runtime_c/service_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_GetResult)();
+
+#ifdef __cplusplus
+}
+#endif
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__action__Fibonacci_FeedbackMessage(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__action__Fibonacci_FeedbackMessage(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, action, Fibonacci_FeedbackMessage)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__ACTION__FIBONACCI__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/action/detail/fibonacci__struct.h
+++ b/src/example_interfaces/action/detail/fibonacci__struct.h
@@ -1,0 +1,214 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:action/Fibonacci.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__ACTION__DETAIL__FIBONACCI__STRUCT_H_
+#define EXAMPLE_INTERFACES__ACTION__DETAIL__FIBONACCI__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in action/Fibonacci in the package example_interfaces.
+typedef struct example_interfaces__action__Fibonacci_Goal
+{
+  int32_t order;
+} example_interfaces__action__Fibonacci_Goal;
+
+// Struct for a sequence of example_interfaces__action__Fibonacci_Goal.
+typedef struct example_interfaces__action__Fibonacci_Goal__Sequence
+{
+  example_interfaces__action__Fibonacci_Goal * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__action__Fibonacci_Goal__Sequence;
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'sequence'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in action/Fibonacci in the package example_interfaces.
+typedef struct example_interfaces__action__Fibonacci_Result
+{
+  rosidl_runtime_c__int32__Sequence sequence;
+} example_interfaces__action__Fibonacci_Result;
+
+// Struct for a sequence of example_interfaces__action__Fibonacci_Result.
+typedef struct example_interfaces__action__Fibonacci_Result__Sequence
+{
+  example_interfaces__action__Fibonacci_Result * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__action__Fibonacci_Result__Sequence;
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'sequence'
+// already included above
+// #include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in action/Fibonacci in the package example_interfaces.
+typedef struct example_interfaces__action__Fibonacci_Feedback
+{
+  rosidl_runtime_c__int32__Sequence sequence;
+} example_interfaces__action__Fibonacci_Feedback;
+
+// Struct for a sequence of example_interfaces__action__Fibonacci_Feedback.
+typedef struct example_interfaces__action__Fibonacci_Feedback__Sequence
+{
+  example_interfaces__action__Fibonacci_Feedback * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__action__Fibonacci_Feedback__Sequence;
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'goal_id'
+#include "unique_identifier_msgs/msg/detail/uuid__struct.h"
+// Member 'goal'
+#include "example_interfaces/action/detail/fibonacci__struct.h"
+
+// Struct defined in action/Fibonacci in the package example_interfaces.
+typedef struct example_interfaces__action__Fibonacci_SendGoal_Request
+{
+  unique_identifier_msgs__msg__UUID goal_id;
+  example_interfaces__action__Fibonacci_Goal goal;
+} example_interfaces__action__Fibonacci_SendGoal_Request;
+
+// Struct for a sequence of example_interfaces__action__Fibonacci_SendGoal_Request.
+typedef struct example_interfaces__action__Fibonacci_SendGoal_Request__Sequence
+{
+  example_interfaces__action__Fibonacci_SendGoal_Request * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__action__Fibonacci_SendGoal_Request__Sequence;
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'stamp'
+#include "builtin_interfaces/msg/detail/time__struct.h"
+
+// Struct defined in action/Fibonacci in the package example_interfaces.
+typedef struct example_interfaces__action__Fibonacci_SendGoal_Response
+{
+  bool accepted;
+  builtin_interfaces__msg__Time stamp;
+} example_interfaces__action__Fibonacci_SendGoal_Response;
+
+// Struct for a sequence of example_interfaces__action__Fibonacci_SendGoal_Response.
+typedef struct example_interfaces__action__Fibonacci_SendGoal_Response__Sequence
+{
+  example_interfaces__action__Fibonacci_SendGoal_Response * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__action__Fibonacci_SendGoal_Response__Sequence;
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'goal_id'
+// already included above
+// #include "unique_identifier_msgs/msg/detail/uuid__struct.h"
+
+// Struct defined in action/Fibonacci in the package example_interfaces.
+typedef struct example_interfaces__action__Fibonacci_GetResult_Request
+{
+  unique_identifier_msgs__msg__UUID goal_id;
+} example_interfaces__action__Fibonacci_GetResult_Request;
+
+// Struct for a sequence of example_interfaces__action__Fibonacci_GetResult_Request.
+typedef struct example_interfaces__action__Fibonacci_GetResult_Request__Sequence
+{
+  example_interfaces__action__Fibonacci_GetResult_Request * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__action__Fibonacci_GetResult_Request__Sequence;
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'result'
+// already included above
+// #include "example_interfaces/action/detail/fibonacci__struct.h"
+
+// Struct defined in action/Fibonacci in the package example_interfaces.
+typedef struct example_interfaces__action__Fibonacci_GetResult_Response
+{
+  int8_t status;
+  example_interfaces__action__Fibonacci_Result result;
+} example_interfaces__action__Fibonacci_GetResult_Response;
+
+// Struct for a sequence of example_interfaces__action__Fibonacci_GetResult_Response.
+typedef struct example_interfaces__action__Fibonacci_GetResult_Response__Sequence
+{
+  example_interfaces__action__Fibonacci_GetResult_Response * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__action__Fibonacci_GetResult_Response__Sequence;
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'goal_id'
+// already included above
+// #include "unique_identifier_msgs/msg/detail/uuid__struct.h"
+// Member 'feedback'
+// already included above
+// #include "example_interfaces/action/detail/fibonacci__struct.h"
+
+// Struct defined in action/Fibonacci in the package example_interfaces.
+typedef struct example_interfaces__action__Fibonacci_FeedbackMessage
+{
+  unique_identifier_msgs__msg__UUID goal_id;
+  example_interfaces__action__Fibonacci_Feedback feedback;
+} example_interfaces__action__Fibonacci_FeedbackMessage;
+
+// Struct for a sequence of example_interfaces__action__Fibonacci_FeedbackMessage.
+typedef struct example_interfaces__action__Fibonacci_FeedbackMessage__Sequence
+{
+  example_interfaces__action__Fibonacci_FeedbackMessage * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__action__Fibonacci_FeedbackMessage__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__ACTION__DETAIL__FIBONACCI__STRUCT_H_

--- a/src/example_interfaces/action/detail/fibonacci__type_support.h
+++ b/src/example_interfaces/action/detail/fibonacci__type_support.h
@@ -1,0 +1,161 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:action/Fibonacci.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__ACTION__DETAIL__FIBONACCI__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__ACTION__DETAIL__FIBONACCI__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/action_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_action_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__ACTION_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci
+)();
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_Goal
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_Result
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_Feedback
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_SendGoal_Request
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_SendGoal_Response
+)();
+
+#include "rosidl_runtime_c/service_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_SendGoal
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_GetResult_Request
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_GetResult_Response
+)();
+
+// already included above
+// #include "rosidl_runtime_c/service_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_GetResult
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  action,
+  Fibonacci_FeedbackMessage
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__ACTION__DETAIL__FIBONACCI__TYPE_SUPPORT_H_

--- a/src/example_interfaces/action/fibonacci.h
+++ b/src/example_interfaces/action/fibonacci.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:action/Fibonacci.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__ACTION__FIBONACCI_H_
+#define EXAMPLE_INTERFACES__ACTION__FIBONACCI_H_
+
+#include "example_interfaces/action/detail/fibonacci__struct.h"
+#include "example_interfaces/action/detail/fibonacci__functions.h"
+#include "example_interfaces/action/detail/fibonacci__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__ACTION__FIBONACCI_H_

--- a/src/example_interfaces/msg/bool.h
+++ b/src/example_interfaces/msg/bool.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Bool.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__BOOL_H_
+#define EXAMPLE_INTERFACES__MSG__BOOL_H_
+
+#include "example_interfaces/msg/detail/bool__struct.h"
+#include "example_interfaces/msg/detail/bool__functions.h"
+#include "example_interfaces/msg/detail/bool__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__BOOL_H_

--- a/src/example_interfaces/msg/byte.h
+++ b/src/example_interfaces/msg/byte.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Byte.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__BYTE_H_
+#define EXAMPLE_INTERFACES__MSG__BYTE_H_
+
+#include "example_interfaces/msg/detail/byte__struct.h"
+#include "example_interfaces/msg/detail/byte__functions.h"
+#include "example_interfaces/msg/detail/byte__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__BYTE_H_

--- a/src/example_interfaces/msg/byte_multi_array.h
+++ b/src/example_interfaces/msg/byte_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/ByteMultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__BYTE_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__BYTE_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/byte_multi_array__struct.h"
+#include "example_interfaces/msg/detail/byte_multi_array__functions.h"
+#include "example_interfaces/msg/detail/byte_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__BYTE_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/char.h
+++ b/src/example_interfaces/msg/char.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Char.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__CHAR_H_
+#define EXAMPLE_INTERFACES__MSG__CHAR_H_
+
+#include "example_interfaces/msg/detail/char__struct.h"
+#include "example_interfaces/msg/detail/char__functions.h"
+#include "example_interfaces/msg/detail/char__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__CHAR_H_

--- a/src/example_interfaces/msg/detail/bool__functions.h
+++ b/src/example_interfaces/msg/detail/bool__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Bool.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__BOOL__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__BOOL__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/bool__struct.h"
+
+/// Initialize msg/Bool message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Bool
+ * )) before or use
+ * example_interfaces__msg__Bool__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Bool__init(example_interfaces__msg__Bool * msg);
+
+/// Finalize msg/Bool message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Bool__fini(example_interfaces__msg__Bool * msg);
+
+/// Create msg/Bool message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Bool__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Bool *
+example_interfaces__msg__Bool__create();
+
+/// Destroy msg/Bool message.
+/**
+ * It calls
+ * example_interfaces__msg__Bool__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Bool__destroy(example_interfaces__msg__Bool * msg);
+
+
+/// Initialize array of msg/Bool messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Bool__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Bool__Sequence__init(example_interfaces__msg__Bool__Sequence * array, size_t size);
+
+/// Finalize array of msg/Bool messages.
+/**
+ * It calls
+ * example_interfaces__msg__Bool__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Bool__Sequence__fini(example_interfaces__msg__Bool__Sequence * array);
+
+/// Create array of msg/Bool messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Bool__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Bool__Sequence *
+example_interfaces__msg__Bool__Sequence__create(size_t size);
+
+/// Destroy array of msg/Bool messages.
+/**
+ * It calls
+ * example_interfaces__msg__Bool__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Bool__Sequence__destroy(example_interfaces__msg__Bool__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__BOOL__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/bool__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/bool__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Bool.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__BOOL__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__BOOL__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Bool(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Bool(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Bool)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__BOOL__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/bool__struct.h
+++ b/src/example_interfaces/msg/detail/bool__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Bool.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__BOOL__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__BOOL__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Bool in the package example_interfaces.
+typedef struct example_interfaces__msg__Bool
+{
+  bool data;
+} example_interfaces__msg__Bool;
+
+// Struct for a sequence of example_interfaces__msg__Bool.
+typedef struct example_interfaces__msg__Bool__Sequence
+{
+  example_interfaces__msg__Bool * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Bool__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__BOOL__STRUCT_H_

--- a/src/example_interfaces/msg/detail/bool__type_support.h
+++ b/src/example_interfaces/msg/detail/bool__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Bool.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__BOOL__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__BOOL__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Bool
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__BOOL__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/byte__functions.h
+++ b/src/example_interfaces/msg/detail/byte__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Byte.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__BYTE__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__BYTE__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/byte__struct.h"
+
+/// Initialize msg/Byte message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Byte
+ * )) before or use
+ * example_interfaces__msg__Byte__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Byte__init(example_interfaces__msg__Byte * msg);
+
+/// Finalize msg/Byte message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Byte__fini(example_interfaces__msg__Byte * msg);
+
+/// Create msg/Byte message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Byte__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Byte *
+example_interfaces__msg__Byte__create();
+
+/// Destroy msg/Byte message.
+/**
+ * It calls
+ * example_interfaces__msg__Byte__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Byte__destroy(example_interfaces__msg__Byte * msg);
+
+
+/// Initialize array of msg/Byte messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Byte__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Byte__Sequence__init(example_interfaces__msg__Byte__Sequence * array, size_t size);
+
+/// Finalize array of msg/Byte messages.
+/**
+ * It calls
+ * example_interfaces__msg__Byte__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Byte__Sequence__fini(example_interfaces__msg__Byte__Sequence * array);
+
+/// Create array of msg/Byte messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Byte__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Byte__Sequence *
+example_interfaces__msg__Byte__Sequence__create(size_t size);
+
+/// Destroy array of msg/Byte messages.
+/**
+ * It calls
+ * example_interfaces__msg__Byte__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Byte__Sequence__destroy(example_interfaces__msg__Byte__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__BYTE__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/byte__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/byte__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Byte.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__BYTE__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__BYTE__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Byte(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Byte(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Byte)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__BYTE__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/byte__struct.h
+++ b/src/example_interfaces/msg/detail/byte__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Byte.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__BYTE__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__BYTE__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Byte in the package example_interfaces.
+typedef struct example_interfaces__msg__Byte
+{
+  uint8_t data;
+} example_interfaces__msg__Byte;
+
+// Struct for a sequence of example_interfaces__msg__Byte.
+typedef struct example_interfaces__msg__Byte__Sequence
+{
+  example_interfaces__msg__Byte * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Byte__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__BYTE__STRUCT_H_

--- a/src/example_interfaces/msg/detail/byte__type_support.h
+++ b/src/example_interfaces/msg/detail/byte__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Byte.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__BYTE__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__BYTE__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Byte
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__BYTE__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/byte_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/byte_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/ByteMultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__BYTE_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__BYTE_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/byte_multi_array__struct.h"
+
+/// Initialize msg/ByteMultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__ByteMultiArray
+ * )) before or use
+ * example_interfaces__msg__ByteMultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__ByteMultiArray__init(example_interfaces__msg__ByteMultiArray * msg);
+
+/// Finalize msg/ByteMultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__ByteMultiArray__fini(example_interfaces__msg__ByteMultiArray * msg);
+
+/// Create msg/ByteMultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__ByteMultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__ByteMultiArray *
+example_interfaces__msg__ByteMultiArray__create();
+
+/// Destroy msg/ByteMultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__ByteMultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__ByteMultiArray__destroy(example_interfaces__msg__ByteMultiArray * msg);
+
+
+/// Initialize array of msg/ByteMultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__ByteMultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__ByteMultiArray__Sequence__init(example_interfaces__msg__ByteMultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/ByteMultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__ByteMultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__ByteMultiArray__Sequence__fini(example_interfaces__msg__ByteMultiArray__Sequence * array);
+
+/// Create array of msg/ByteMultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__ByteMultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__ByteMultiArray__Sequence *
+example_interfaces__msg__ByteMultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/ByteMultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__ByteMultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__ByteMultiArray__Sequence__destroy(example_interfaces__msg__ByteMultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__BYTE_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/byte_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/byte_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/ByteMultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__BYTE_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__BYTE_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__ByteMultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__ByteMultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, ByteMultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__BYTE_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/byte_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/byte_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/ByteMultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__BYTE_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__BYTE_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/ByteMultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__ByteMultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__octet__Sequence data;
+} example_interfaces__msg__ByteMultiArray;
+
+// Struct for a sequence of example_interfaces__msg__ByteMultiArray.
+typedef struct example_interfaces__msg__ByteMultiArray__Sequence
+{
+  example_interfaces__msg__ByteMultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__ByteMultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__BYTE_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/byte_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/byte_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/ByteMultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__BYTE_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__BYTE_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  ByteMultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__BYTE_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/char__functions.h
+++ b/src/example_interfaces/msg/detail/char__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Char.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__CHAR__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__CHAR__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/char__struct.h"
+
+/// Initialize msg/Char message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Char
+ * )) before or use
+ * example_interfaces__msg__Char__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Char__init(example_interfaces__msg__Char * msg);
+
+/// Finalize msg/Char message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Char__fini(example_interfaces__msg__Char * msg);
+
+/// Create msg/Char message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Char__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Char *
+example_interfaces__msg__Char__create();
+
+/// Destroy msg/Char message.
+/**
+ * It calls
+ * example_interfaces__msg__Char__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Char__destroy(example_interfaces__msg__Char * msg);
+
+
+/// Initialize array of msg/Char messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Char__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Char__Sequence__init(example_interfaces__msg__Char__Sequence * array, size_t size);
+
+/// Finalize array of msg/Char messages.
+/**
+ * It calls
+ * example_interfaces__msg__Char__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Char__Sequence__fini(example_interfaces__msg__Char__Sequence * array);
+
+/// Create array of msg/Char messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Char__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Char__Sequence *
+example_interfaces__msg__Char__Sequence__create(size_t size);
+
+/// Destroy array of msg/Char messages.
+/**
+ * It calls
+ * example_interfaces__msg__Char__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Char__Sequence__destroy(example_interfaces__msg__Char__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__CHAR__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/char__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/char__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Char.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__CHAR__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__CHAR__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Char(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Char(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Char)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__CHAR__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/char__struct.h
+++ b/src/example_interfaces/msg/detail/char__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Char.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__CHAR__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__CHAR__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Char in the package example_interfaces.
+typedef struct example_interfaces__msg__Char
+{
+  uint8_t data;
+} example_interfaces__msg__Char;
+
+// Struct for a sequence of example_interfaces__msg__Char.
+typedef struct example_interfaces__msg__Char__Sequence
+{
+  example_interfaces__msg__Char * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Char__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__CHAR__STRUCT_H_

--- a/src/example_interfaces/msg/detail/char__type_support.h
+++ b/src/example_interfaces/msg/detail/char__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Char.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__CHAR__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__CHAR__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Char
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__CHAR__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/empty__functions.h
+++ b/src/example_interfaces/msg/detail/empty__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Empty.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__EMPTY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__EMPTY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/empty__struct.h"
+
+/// Initialize msg/Empty message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Empty
+ * )) before or use
+ * example_interfaces__msg__Empty__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Empty__init(example_interfaces__msg__Empty * msg);
+
+/// Finalize msg/Empty message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Empty__fini(example_interfaces__msg__Empty * msg);
+
+/// Create msg/Empty message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Empty__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Empty *
+example_interfaces__msg__Empty__create();
+
+/// Destroy msg/Empty message.
+/**
+ * It calls
+ * example_interfaces__msg__Empty__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Empty__destroy(example_interfaces__msg__Empty * msg);
+
+
+/// Initialize array of msg/Empty messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Empty__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Empty__Sequence__init(example_interfaces__msg__Empty__Sequence * array, size_t size);
+
+/// Finalize array of msg/Empty messages.
+/**
+ * It calls
+ * example_interfaces__msg__Empty__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Empty__Sequence__fini(example_interfaces__msg__Empty__Sequence * array);
+
+/// Create array of msg/Empty messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Empty__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Empty__Sequence *
+example_interfaces__msg__Empty__Sequence__create(size_t size);
+
+/// Destroy array of msg/Empty messages.
+/**
+ * It calls
+ * example_interfaces__msg__Empty__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Empty__Sequence__destroy(example_interfaces__msg__Empty__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__EMPTY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/empty__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/empty__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Empty.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__EMPTY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__EMPTY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Empty(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Empty(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Empty)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__EMPTY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/empty__struct.h
+++ b/src/example_interfaces/msg/detail/empty__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Empty.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__EMPTY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__EMPTY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Empty in the package example_interfaces.
+typedef struct example_interfaces__msg__Empty
+{
+  uint8_t structure_needs_at_least_one_member;
+} example_interfaces__msg__Empty;
+
+// Struct for a sequence of example_interfaces__msg__Empty.
+typedef struct example_interfaces__msg__Empty__Sequence
+{
+  example_interfaces__msg__Empty * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Empty__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__EMPTY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/empty__type_support.h
+++ b/src/example_interfaces/msg/detail/empty__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Empty.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__EMPTY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__EMPTY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Empty
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__EMPTY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/float32__functions.h
+++ b/src/example_interfaces/msg/detail/float32__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Float32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/float32__struct.h"
+
+/// Initialize msg/Float32 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Float32
+ * )) before or use
+ * example_interfaces__msg__Float32__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Float32__init(example_interfaces__msg__Float32 * msg);
+
+/// Finalize msg/Float32 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float32__fini(example_interfaces__msg__Float32 * msg);
+
+/// Create msg/Float32 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Float32__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Float32 *
+example_interfaces__msg__Float32__create();
+
+/// Destroy msg/Float32 message.
+/**
+ * It calls
+ * example_interfaces__msg__Float32__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float32__destroy(example_interfaces__msg__Float32 * msg);
+
+
+/// Initialize array of msg/Float32 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Float32__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Float32__Sequence__init(example_interfaces__msg__Float32__Sequence * array, size_t size);
+
+/// Finalize array of msg/Float32 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Float32__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float32__Sequence__fini(example_interfaces__msg__Float32__Sequence * array);
+
+/// Create array of msg/Float32 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Float32__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Float32__Sequence *
+example_interfaces__msg__Float32__Sequence__create(size_t size);
+
+/// Destroy array of msg/Float32 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Float32__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float32__Sequence__destroy(example_interfaces__msg__Float32__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/float32__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/float32__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Float32.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__FLOAT32__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__FLOAT32__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Float32(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Float32(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Float32)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__FLOAT32__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/float32__struct.h
+++ b/src/example_interfaces/msg/detail/float32__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Float32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Float32 in the package example_interfaces.
+typedef struct example_interfaces__msg__Float32
+{
+  float data;
+} example_interfaces__msg__Float32;
+
+// Struct for a sequence of example_interfaces__msg__Float32.
+typedef struct example_interfaces__msg__Float32__Sequence
+{
+  example_interfaces__msg__Float32 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Float32__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32__STRUCT_H_

--- a/src/example_interfaces/msg/detail/float32__type_support.h
+++ b/src/example_interfaces/msg/detail/float32__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Float32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Float32
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/float32_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/float32_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Float32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/float32_multi_array__struct.h"
+
+/// Initialize msg/Float32MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Float32MultiArray
+ * )) before or use
+ * example_interfaces__msg__Float32MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Float32MultiArray__init(example_interfaces__msg__Float32MultiArray * msg);
+
+/// Finalize msg/Float32MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float32MultiArray__fini(example_interfaces__msg__Float32MultiArray * msg);
+
+/// Create msg/Float32MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Float32MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Float32MultiArray *
+example_interfaces__msg__Float32MultiArray__create();
+
+/// Destroy msg/Float32MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__Float32MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float32MultiArray__destroy(example_interfaces__msg__Float32MultiArray * msg);
+
+
+/// Initialize array of msg/Float32MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Float32MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Float32MultiArray__Sequence__init(example_interfaces__msg__Float32MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/Float32MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Float32MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float32MultiArray__Sequence__fini(example_interfaces__msg__Float32MultiArray__Sequence * array);
+
+/// Create array of msg/Float32MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Float32MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Float32MultiArray__Sequence *
+example_interfaces__msg__Float32MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/Float32MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Float32MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float32MultiArray__Sequence__destroy(example_interfaces__msg__Float32MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/float32_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/float32_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Float32MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__FLOAT32_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__FLOAT32_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Float32MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Float32MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Float32MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__FLOAT32_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/float32_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/float32_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Float32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/Float32MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__Float32MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__float__Sequence data;
+} example_interfaces__msg__Float32MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__Float32MultiArray.
+typedef struct example_interfaces__msg__Float32MultiArray__Sequence
+{
+  example_interfaces__msg__Float32MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Float32MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/float32_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/float32_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Float32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Float32MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT32_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/float64__functions.h
+++ b/src/example_interfaces/msg/detail/float64__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Float64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/float64__struct.h"
+
+/// Initialize msg/Float64 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Float64
+ * )) before or use
+ * example_interfaces__msg__Float64__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Float64__init(example_interfaces__msg__Float64 * msg);
+
+/// Finalize msg/Float64 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float64__fini(example_interfaces__msg__Float64 * msg);
+
+/// Create msg/Float64 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Float64__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Float64 *
+example_interfaces__msg__Float64__create();
+
+/// Destroy msg/Float64 message.
+/**
+ * It calls
+ * example_interfaces__msg__Float64__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float64__destroy(example_interfaces__msg__Float64 * msg);
+
+
+/// Initialize array of msg/Float64 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Float64__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Float64__Sequence__init(example_interfaces__msg__Float64__Sequence * array, size_t size);
+
+/// Finalize array of msg/Float64 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Float64__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float64__Sequence__fini(example_interfaces__msg__Float64__Sequence * array);
+
+/// Create array of msg/Float64 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Float64__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Float64__Sequence *
+example_interfaces__msg__Float64__Sequence__create(size_t size);
+
+/// Destroy array of msg/Float64 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Float64__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float64__Sequence__destroy(example_interfaces__msg__Float64__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/float64__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/float64__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Float64.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__FLOAT64__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__FLOAT64__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Float64(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Float64(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Float64)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__FLOAT64__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/float64__struct.h
+++ b/src/example_interfaces/msg/detail/float64__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Float64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Float64 in the package example_interfaces.
+typedef struct example_interfaces__msg__Float64
+{
+  double data;
+} example_interfaces__msg__Float64;
+
+// Struct for a sequence of example_interfaces__msg__Float64.
+typedef struct example_interfaces__msg__Float64__Sequence
+{
+  example_interfaces__msg__Float64 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Float64__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64__STRUCT_H_

--- a/src/example_interfaces/msg/detail/float64__type_support.h
+++ b/src/example_interfaces/msg/detail/float64__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Float64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Float64
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/float64_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/float64_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Float64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/float64_multi_array__struct.h"
+
+/// Initialize msg/Float64MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Float64MultiArray
+ * )) before or use
+ * example_interfaces__msg__Float64MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Float64MultiArray__init(example_interfaces__msg__Float64MultiArray * msg);
+
+/// Finalize msg/Float64MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float64MultiArray__fini(example_interfaces__msg__Float64MultiArray * msg);
+
+/// Create msg/Float64MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Float64MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Float64MultiArray *
+example_interfaces__msg__Float64MultiArray__create();
+
+/// Destroy msg/Float64MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__Float64MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float64MultiArray__destroy(example_interfaces__msg__Float64MultiArray * msg);
+
+
+/// Initialize array of msg/Float64MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Float64MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Float64MultiArray__Sequence__init(example_interfaces__msg__Float64MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/Float64MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Float64MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float64MultiArray__Sequence__fini(example_interfaces__msg__Float64MultiArray__Sequence * array);
+
+/// Create array of msg/Float64MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Float64MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Float64MultiArray__Sequence *
+example_interfaces__msg__Float64MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/Float64MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Float64MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Float64MultiArray__Sequence__destroy(example_interfaces__msg__Float64MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/float64_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/float64_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Float64MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__FLOAT64_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__FLOAT64_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Float64MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Float64MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Float64MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__FLOAT64_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/float64_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/float64_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Float64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/Float64MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__Float64MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__double__Sequence data;
+} example_interfaces__msg__Float64MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__Float64MultiArray.
+typedef struct example_interfaces__msg__Float64MultiArray__Sequence
+{
+  example_interfaces__msg__Float64MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Float64MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/float64_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/float64_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Float64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Float64MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__FLOAT64_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/int16__functions.h
+++ b/src/example_interfaces/msg/detail/int16__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Int16.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT16__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT16__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/int16__struct.h"
+
+/// Initialize msg/Int16 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Int16
+ * )) before or use
+ * example_interfaces__msg__Int16__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int16__init(example_interfaces__msg__Int16 * msg);
+
+/// Finalize msg/Int16 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int16__fini(example_interfaces__msg__Int16 * msg);
+
+/// Create msg/Int16 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Int16__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int16 *
+example_interfaces__msg__Int16__create();
+
+/// Destroy msg/Int16 message.
+/**
+ * It calls
+ * example_interfaces__msg__Int16__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int16__destroy(example_interfaces__msg__Int16 * msg);
+
+
+/// Initialize array of msg/Int16 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Int16__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int16__Sequence__init(example_interfaces__msg__Int16__Sequence * array, size_t size);
+
+/// Finalize array of msg/Int16 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int16__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int16__Sequence__fini(example_interfaces__msg__Int16__Sequence * array);
+
+/// Create array of msg/Int16 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Int16__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int16__Sequence *
+example_interfaces__msg__Int16__Sequence__create(size_t size);
+
+/// Destroy array of msg/Int16 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int16__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int16__Sequence__destroy(example_interfaces__msg__Int16__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT16__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/int16__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/int16__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Int16.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__INT16__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__INT16__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Int16(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Int16(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Int16)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT16__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/int16__struct.h
+++ b/src/example_interfaces/msg/detail/int16__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Int16.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT16__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT16__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Int16 in the package example_interfaces.
+typedef struct example_interfaces__msg__Int16
+{
+  int16_t data;
+} example_interfaces__msg__Int16;
+
+// Struct for a sequence of example_interfaces__msg__Int16.
+typedef struct example_interfaces__msg__Int16__Sequence
+{
+  example_interfaces__msg__Int16 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Int16__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT16__STRUCT_H_

--- a/src/example_interfaces/msg/detail/int16__type_support.h
+++ b/src/example_interfaces/msg/detail/int16__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Int16.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT16__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT16__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Int16
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT16__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/int16_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/int16_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Int16MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT16_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT16_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/int16_multi_array__struct.h"
+
+/// Initialize msg/Int16MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Int16MultiArray
+ * )) before or use
+ * example_interfaces__msg__Int16MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int16MultiArray__init(example_interfaces__msg__Int16MultiArray * msg);
+
+/// Finalize msg/Int16MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int16MultiArray__fini(example_interfaces__msg__Int16MultiArray * msg);
+
+/// Create msg/Int16MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Int16MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int16MultiArray *
+example_interfaces__msg__Int16MultiArray__create();
+
+/// Destroy msg/Int16MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__Int16MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int16MultiArray__destroy(example_interfaces__msg__Int16MultiArray * msg);
+
+
+/// Initialize array of msg/Int16MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Int16MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int16MultiArray__Sequence__init(example_interfaces__msg__Int16MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/Int16MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int16MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int16MultiArray__Sequence__fini(example_interfaces__msg__Int16MultiArray__Sequence * array);
+
+/// Create array of msg/Int16MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Int16MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int16MultiArray__Sequence *
+example_interfaces__msg__Int16MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/Int16MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int16MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int16MultiArray__Sequence__destroy(example_interfaces__msg__Int16MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT16_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/int16_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/int16_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Int16MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__INT16_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__INT16_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Int16MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Int16MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Int16MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT16_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/int16_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/int16_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Int16MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT16_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT16_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/Int16MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__Int16MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__int16__Sequence data;
+} example_interfaces__msg__Int16MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__Int16MultiArray.
+typedef struct example_interfaces__msg__Int16MultiArray__Sequence
+{
+  example_interfaces__msg__Int16MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Int16MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT16_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/int16_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/int16_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Int16MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT16_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT16_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Int16MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT16_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/int32__functions.h
+++ b/src/example_interfaces/msg/detail/int32__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Int32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT32__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT32__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/int32__struct.h"
+
+/// Initialize msg/Int32 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Int32
+ * )) before or use
+ * example_interfaces__msg__Int32__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int32__init(example_interfaces__msg__Int32 * msg);
+
+/// Finalize msg/Int32 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int32__fini(example_interfaces__msg__Int32 * msg);
+
+/// Create msg/Int32 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Int32__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int32 *
+example_interfaces__msg__Int32__create();
+
+/// Destroy msg/Int32 message.
+/**
+ * It calls
+ * example_interfaces__msg__Int32__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int32__destroy(example_interfaces__msg__Int32 * msg);
+
+
+/// Initialize array of msg/Int32 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Int32__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int32__Sequence__init(example_interfaces__msg__Int32__Sequence * array, size_t size);
+
+/// Finalize array of msg/Int32 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int32__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int32__Sequence__fini(example_interfaces__msg__Int32__Sequence * array);
+
+/// Create array of msg/Int32 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Int32__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int32__Sequence *
+example_interfaces__msg__Int32__Sequence__create(size_t size);
+
+/// Destroy array of msg/Int32 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int32__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int32__Sequence__destroy(example_interfaces__msg__Int32__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT32__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/int32__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/int32__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Int32.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__INT32__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__INT32__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Int32(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Int32(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Int32)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT32__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/int32__struct.h
+++ b/src/example_interfaces/msg/detail/int32__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Int32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT32__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT32__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Int32 in the package example_interfaces.
+typedef struct example_interfaces__msg__Int32
+{
+  int32_t data;
+} example_interfaces__msg__Int32;
+
+// Struct for a sequence of example_interfaces__msg__Int32.
+typedef struct example_interfaces__msg__Int32__Sequence
+{
+  example_interfaces__msg__Int32 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Int32__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT32__STRUCT_H_

--- a/src/example_interfaces/msg/detail/int32__type_support.h
+++ b/src/example_interfaces/msg/detail/int32__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Int32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT32__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT32__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Int32
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT32__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/int32_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/int32_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Int32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT32_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT32_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/int32_multi_array__struct.h"
+
+/// Initialize msg/Int32MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Int32MultiArray
+ * )) before or use
+ * example_interfaces__msg__Int32MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int32MultiArray__init(example_interfaces__msg__Int32MultiArray * msg);
+
+/// Finalize msg/Int32MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int32MultiArray__fini(example_interfaces__msg__Int32MultiArray * msg);
+
+/// Create msg/Int32MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Int32MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int32MultiArray *
+example_interfaces__msg__Int32MultiArray__create();
+
+/// Destroy msg/Int32MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__Int32MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int32MultiArray__destroy(example_interfaces__msg__Int32MultiArray * msg);
+
+
+/// Initialize array of msg/Int32MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Int32MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int32MultiArray__Sequence__init(example_interfaces__msg__Int32MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/Int32MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int32MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int32MultiArray__Sequence__fini(example_interfaces__msg__Int32MultiArray__Sequence * array);
+
+/// Create array of msg/Int32MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Int32MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int32MultiArray__Sequence *
+example_interfaces__msg__Int32MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/Int32MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int32MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int32MultiArray__Sequence__destroy(example_interfaces__msg__Int32MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT32_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/int32_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/int32_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Int32MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__INT32_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__INT32_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Int32MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Int32MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Int32MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT32_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/int32_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/int32_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Int32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT32_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT32_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/Int32MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__Int32MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__int32__Sequence data;
+} example_interfaces__msg__Int32MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__Int32MultiArray.
+typedef struct example_interfaces__msg__Int32MultiArray__Sequence
+{
+  example_interfaces__msg__Int32MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Int32MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT32_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/int32_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/int32_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Int32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT32_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT32_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Int32MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT32_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/int64__functions.h
+++ b/src/example_interfaces/msg/detail/int64__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Int64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT64__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT64__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/int64__struct.h"
+
+/// Initialize msg/Int64 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Int64
+ * )) before or use
+ * example_interfaces__msg__Int64__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int64__init(example_interfaces__msg__Int64 * msg);
+
+/// Finalize msg/Int64 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int64__fini(example_interfaces__msg__Int64 * msg);
+
+/// Create msg/Int64 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Int64__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int64 *
+example_interfaces__msg__Int64__create();
+
+/// Destroy msg/Int64 message.
+/**
+ * It calls
+ * example_interfaces__msg__Int64__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int64__destroy(example_interfaces__msg__Int64 * msg);
+
+
+/// Initialize array of msg/Int64 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Int64__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int64__Sequence__init(example_interfaces__msg__Int64__Sequence * array, size_t size);
+
+/// Finalize array of msg/Int64 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int64__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int64__Sequence__fini(example_interfaces__msg__Int64__Sequence * array);
+
+/// Create array of msg/Int64 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Int64__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int64__Sequence *
+example_interfaces__msg__Int64__Sequence__create(size_t size);
+
+/// Destroy array of msg/Int64 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int64__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int64__Sequence__destroy(example_interfaces__msg__Int64__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT64__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/int64__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/int64__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Int64.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__INT64__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__INT64__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Int64(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Int64(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Int64)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT64__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/int64__struct.h
+++ b/src/example_interfaces/msg/detail/int64__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Int64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT64__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT64__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Int64 in the package example_interfaces.
+typedef struct example_interfaces__msg__Int64
+{
+  int64_t data;
+} example_interfaces__msg__Int64;
+
+// Struct for a sequence of example_interfaces__msg__Int64.
+typedef struct example_interfaces__msg__Int64__Sequence
+{
+  example_interfaces__msg__Int64 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Int64__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT64__STRUCT_H_

--- a/src/example_interfaces/msg/detail/int64__type_support.h
+++ b/src/example_interfaces/msg/detail/int64__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Int64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT64__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT64__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Int64
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT64__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/int64_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/int64_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Int64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT64_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT64_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/int64_multi_array__struct.h"
+
+/// Initialize msg/Int64MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Int64MultiArray
+ * )) before or use
+ * example_interfaces__msg__Int64MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int64MultiArray__init(example_interfaces__msg__Int64MultiArray * msg);
+
+/// Finalize msg/Int64MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int64MultiArray__fini(example_interfaces__msg__Int64MultiArray * msg);
+
+/// Create msg/Int64MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Int64MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int64MultiArray *
+example_interfaces__msg__Int64MultiArray__create();
+
+/// Destroy msg/Int64MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__Int64MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int64MultiArray__destroy(example_interfaces__msg__Int64MultiArray * msg);
+
+
+/// Initialize array of msg/Int64MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Int64MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int64MultiArray__Sequence__init(example_interfaces__msg__Int64MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/Int64MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int64MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int64MultiArray__Sequence__fini(example_interfaces__msg__Int64MultiArray__Sequence * array);
+
+/// Create array of msg/Int64MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Int64MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int64MultiArray__Sequence *
+example_interfaces__msg__Int64MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/Int64MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int64MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int64MultiArray__Sequence__destroy(example_interfaces__msg__Int64MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT64_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/int64_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/int64_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Int64MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__INT64_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__INT64_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Int64MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Int64MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Int64MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT64_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/int64_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/int64_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Int64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT64_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT64_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/Int64MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__Int64MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__int64__Sequence data;
+} example_interfaces__msg__Int64MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__Int64MultiArray.
+typedef struct example_interfaces__msg__Int64MultiArray__Sequence
+{
+  example_interfaces__msg__Int64MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Int64MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT64_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/int64_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/int64_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Int64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT64_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT64_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Int64MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT64_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/int8__functions.h
+++ b/src/example_interfaces/msg/detail/int8__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Int8.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT8__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT8__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/int8__struct.h"
+
+/// Initialize msg/Int8 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Int8
+ * )) before or use
+ * example_interfaces__msg__Int8__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int8__init(example_interfaces__msg__Int8 * msg);
+
+/// Finalize msg/Int8 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int8__fini(example_interfaces__msg__Int8 * msg);
+
+/// Create msg/Int8 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Int8__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int8 *
+example_interfaces__msg__Int8__create();
+
+/// Destroy msg/Int8 message.
+/**
+ * It calls
+ * example_interfaces__msg__Int8__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int8__destroy(example_interfaces__msg__Int8 * msg);
+
+
+/// Initialize array of msg/Int8 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Int8__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int8__Sequence__init(example_interfaces__msg__Int8__Sequence * array, size_t size);
+
+/// Finalize array of msg/Int8 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int8__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int8__Sequence__fini(example_interfaces__msg__Int8__Sequence * array);
+
+/// Create array of msg/Int8 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Int8__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int8__Sequence *
+example_interfaces__msg__Int8__Sequence__create(size_t size);
+
+/// Destroy array of msg/Int8 messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int8__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int8__Sequence__destroy(example_interfaces__msg__Int8__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT8__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/int8__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/int8__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Int8.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__INT8__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__INT8__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Int8(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Int8(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Int8)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT8__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/int8__struct.h
+++ b/src/example_interfaces/msg/detail/int8__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Int8.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT8__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT8__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/Int8 in the package example_interfaces.
+typedef struct example_interfaces__msg__Int8
+{
+  int8_t data;
+} example_interfaces__msg__Int8;
+
+// Struct for a sequence of example_interfaces__msg__Int8.
+typedef struct example_interfaces__msg__Int8__Sequence
+{
+  example_interfaces__msg__Int8 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Int8__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT8__STRUCT_H_

--- a/src/example_interfaces/msg/detail/int8__type_support.h
+++ b/src/example_interfaces/msg/detail/int8__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Int8.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT8__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT8__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Int8
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT8__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/int8_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/int8_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/Int8MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT8_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT8_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/int8_multi_array__struct.h"
+
+/// Initialize msg/Int8MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__Int8MultiArray
+ * )) before or use
+ * example_interfaces__msg__Int8MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int8MultiArray__init(example_interfaces__msg__Int8MultiArray * msg);
+
+/// Finalize msg/Int8MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int8MultiArray__fini(example_interfaces__msg__Int8MultiArray * msg);
+
+/// Create msg/Int8MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__Int8MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int8MultiArray *
+example_interfaces__msg__Int8MultiArray__create();
+
+/// Destroy msg/Int8MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__Int8MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int8MultiArray__destroy(example_interfaces__msg__Int8MultiArray * msg);
+
+
+/// Initialize array of msg/Int8MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__Int8MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__Int8MultiArray__Sequence__init(example_interfaces__msg__Int8MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/Int8MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int8MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int8MultiArray__Sequence__fini(example_interfaces__msg__Int8MultiArray__Sequence * array);
+
+/// Create array of msg/Int8MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__Int8MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__Int8MultiArray__Sequence *
+example_interfaces__msg__Int8MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/Int8MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__Int8MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__Int8MultiArray__Sequence__destroy(example_interfaces__msg__Int8MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT8_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/int8_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/int8_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/Int8MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__INT8_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__INT8_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__Int8MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__Int8MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, Int8MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT8_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/int8_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/int8_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/Int8MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT8_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT8_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/Int8MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__Int8MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__int8__Sequence data;
+} example_interfaces__msg__Int8MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__Int8MultiArray.
+typedef struct example_interfaces__msg__Int8MultiArray__Sequence
+{
+  example_interfaces__msg__Int8MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__Int8MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT8_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/int8_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/int8_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/Int8MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__INT8_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__INT8_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  Int8MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__INT8_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/multi_array_dimension__functions.h
+++ b/src/example_interfaces/msg/detail/multi_array_dimension__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/MultiArrayDimension.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_DIMENSION__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_DIMENSION__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/multi_array_dimension__struct.h"
+
+/// Initialize msg/MultiArrayDimension message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__MultiArrayDimension
+ * )) before or use
+ * example_interfaces__msg__MultiArrayDimension__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__MultiArrayDimension__init(example_interfaces__msg__MultiArrayDimension * msg);
+
+/// Finalize msg/MultiArrayDimension message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__MultiArrayDimension__fini(example_interfaces__msg__MultiArrayDimension * msg);
+
+/// Create msg/MultiArrayDimension message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__MultiArrayDimension__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__MultiArrayDimension *
+example_interfaces__msg__MultiArrayDimension__create();
+
+/// Destroy msg/MultiArrayDimension message.
+/**
+ * It calls
+ * example_interfaces__msg__MultiArrayDimension__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__MultiArrayDimension__destroy(example_interfaces__msg__MultiArrayDimension * msg);
+
+
+/// Initialize array of msg/MultiArrayDimension messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__MultiArrayDimension__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__MultiArrayDimension__Sequence__init(example_interfaces__msg__MultiArrayDimension__Sequence * array, size_t size);
+
+/// Finalize array of msg/MultiArrayDimension messages.
+/**
+ * It calls
+ * example_interfaces__msg__MultiArrayDimension__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__MultiArrayDimension__Sequence__fini(example_interfaces__msg__MultiArrayDimension__Sequence * array);
+
+/// Create array of msg/MultiArrayDimension messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__MultiArrayDimension__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__MultiArrayDimension__Sequence *
+example_interfaces__msg__MultiArrayDimension__Sequence__create(size_t size);
+
+/// Destroy array of msg/MultiArrayDimension messages.
+/**
+ * It calls
+ * example_interfaces__msg__MultiArrayDimension__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__MultiArrayDimension__Sequence__destroy(example_interfaces__msg__MultiArrayDimension__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_DIMENSION__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/multi_array_dimension__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/multi_array_dimension__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/MultiArrayDimension.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_DIMENSION__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_DIMENSION__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__MultiArrayDimension(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__MultiArrayDimension(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, MultiArrayDimension)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_DIMENSION__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/multi_array_dimension__struct.h
+++ b/src/example_interfaces/msg/detail/multi_array_dimension__struct.h
@@ -1,0 +1,46 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/MultiArrayDimension.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_DIMENSION__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_DIMENSION__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'label'
+#include "rosidl_runtime_c/string.h"
+
+// Struct defined in msg/MultiArrayDimension in the package example_interfaces.
+typedef struct example_interfaces__msg__MultiArrayDimension
+{
+  rosidl_runtime_c__String label;
+  uint32_t size;
+  uint32_t stride;
+} example_interfaces__msg__MultiArrayDimension;
+
+// Struct for a sequence of example_interfaces__msg__MultiArrayDimension.
+typedef struct example_interfaces__msg__MultiArrayDimension__Sequence
+{
+  example_interfaces__msg__MultiArrayDimension * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__MultiArrayDimension__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_DIMENSION__STRUCT_H_

--- a/src/example_interfaces/msg/detail/multi_array_dimension__type_support.h
+++ b/src/example_interfaces/msg/detail/multi_array_dimension__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/MultiArrayDimension.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_DIMENSION__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_DIMENSION__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  MultiArrayDimension
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_DIMENSION__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/multi_array_layout__functions.h
+++ b/src/example_interfaces/msg/detail/multi_array_layout__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/MultiArrayLayout.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_LAYOUT__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_LAYOUT__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+
+/// Initialize msg/MultiArrayLayout message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__MultiArrayLayout
+ * )) before or use
+ * example_interfaces__msg__MultiArrayLayout__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__MultiArrayLayout__init(example_interfaces__msg__MultiArrayLayout * msg);
+
+/// Finalize msg/MultiArrayLayout message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__MultiArrayLayout__fini(example_interfaces__msg__MultiArrayLayout * msg);
+
+/// Create msg/MultiArrayLayout message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__MultiArrayLayout__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__MultiArrayLayout *
+example_interfaces__msg__MultiArrayLayout__create();
+
+/// Destroy msg/MultiArrayLayout message.
+/**
+ * It calls
+ * example_interfaces__msg__MultiArrayLayout__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__MultiArrayLayout__destroy(example_interfaces__msg__MultiArrayLayout * msg);
+
+
+/// Initialize array of msg/MultiArrayLayout messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__MultiArrayLayout__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__MultiArrayLayout__Sequence__init(example_interfaces__msg__MultiArrayLayout__Sequence * array, size_t size);
+
+/// Finalize array of msg/MultiArrayLayout messages.
+/**
+ * It calls
+ * example_interfaces__msg__MultiArrayLayout__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__MultiArrayLayout__Sequence__fini(example_interfaces__msg__MultiArrayLayout__Sequence * array);
+
+/// Create array of msg/MultiArrayLayout messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__MultiArrayLayout__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__MultiArrayLayout__Sequence *
+example_interfaces__msg__MultiArrayLayout__Sequence__create(size_t size);
+
+/// Destroy array of msg/MultiArrayLayout messages.
+/**
+ * It calls
+ * example_interfaces__msg__MultiArrayLayout__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__MultiArrayLayout__Sequence__destroy(example_interfaces__msg__MultiArrayLayout__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_LAYOUT__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/multi_array_layout__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/multi_array_layout__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/MultiArrayLayout.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_LAYOUT__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_LAYOUT__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__MultiArrayLayout(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__MultiArrayLayout(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, MultiArrayLayout)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_LAYOUT__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/multi_array_layout__struct.h
+++ b/src/example_interfaces/msg/detail/multi_array_layout__struct.h
@@ -1,0 +1,45 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/MultiArrayLayout.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_LAYOUT__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_LAYOUT__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'dim'
+#include "example_interfaces/msg/detail/multi_array_dimension__struct.h"
+
+// Struct defined in msg/MultiArrayLayout in the package example_interfaces.
+typedef struct example_interfaces__msg__MultiArrayLayout
+{
+  example_interfaces__msg__MultiArrayDimension__Sequence dim;
+  uint32_t data_offset;
+} example_interfaces__msg__MultiArrayLayout;
+
+// Struct for a sequence of example_interfaces__msg__MultiArrayLayout.
+typedef struct example_interfaces__msg__MultiArrayLayout__Sequence
+{
+  example_interfaces__msg__MultiArrayLayout * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__MultiArrayLayout__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_LAYOUT__STRUCT_H_

--- a/src/example_interfaces/msg/detail/multi_array_layout__type_support.h
+++ b/src/example_interfaces/msg/detail/multi_array_layout__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/MultiArrayLayout.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_LAYOUT__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_LAYOUT__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  MultiArrayLayout
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__MULTI_ARRAY_LAYOUT__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/string__functions.h
+++ b/src/example_interfaces/msg/detail/string__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/String.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__STRING__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__STRING__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/string__struct.h"
+
+/// Initialize msg/String message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__String
+ * )) before or use
+ * example_interfaces__msg__String__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__String__init(example_interfaces__msg__String * msg);
+
+/// Finalize msg/String message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__String__fini(example_interfaces__msg__String * msg);
+
+/// Create msg/String message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__String__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__String *
+example_interfaces__msg__String__create();
+
+/// Destroy msg/String message.
+/**
+ * It calls
+ * example_interfaces__msg__String__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__String__destroy(example_interfaces__msg__String * msg);
+
+
+/// Initialize array of msg/String messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__String__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__String__Sequence__init(example_interfaces__msg__String__Sequence * array, size_t size);
+
+/// Finalize array of msg/String messages.
+/**
+ * It calls
+ * example_interfaces__msg__String__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__String__Sequence__fini(example_interfaces__msg__String__Sequence * array);
+
+/// Create array of msg/String messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__String__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__String__Sequence *
+example_interfaces__msg__String__Sequence__create(size_t size);
+
+/// Destroy array of msg/String messages.
+/**
+ * It calls
+ * example_interfaces__msg__String__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__String__Sequence__destroy(example_interfaces__msg__String__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__STRING__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/string__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/string__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/String.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__STRING__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__STRING__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__String(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__String(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, String)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__STRING__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/string__struct.h
+++ b/src/example_interfaces/msg/detail/string__struct.h
@@ -1,0 +1,44 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/String.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__STRING__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__STRING__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'data'
+#include "rosidl_runtime_c/string.h"
+
+// Struct defined in msg/String in the package example_interfaces.
+typedef struct example_interfaces__msg__String
+{
+  rosidl_runtime_c__String data;
+} example_interfaces__msg__String;
+
+// Struct for a sequence of example_interfaces__msg__String.
+typedef struct example_interfaces__msg__String__Sequence
+{
+  example_interfaces__msg__String * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__String__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__STRING__STRUCT_H_

--- a/src/example_interfaces/msg/detail/string__type_support.h
+++ b/src/example_interfaces/msg/detail/string__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/String.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__STRING__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__STRING__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  String
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__STRING__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/u_int16__functions.h
+++ b/src/example_interfaces/msg/detail/u_int16__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/UInt16.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/u_int16__struct.h"
+
+/// Initialize msg/UInt16 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__UInt16
+ * )) before or use
+ * example_interfaces__msg__UInt16__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt16__init(example_interfaces__msg__UInt16 * msg);
+
+/// Finalize msg/UInt16 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt16__fini(example_interfaces__msg__UInt16 * msg);
+
+/// Create msg/UInt16 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__UInt16__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt16 *
+example_interfaces__msg__UInt16__create();
+
+/// Destroy msg/UInt16 message.
+/**
+ * It calls
+ * example_interfaces__msg__UInt16__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt16__destroy(example_interfaces__msg__UInt16 * msg);
+
+
+/// Initialize array of msg/UInt16 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__UInt16__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt16__Sequence__init(example_interfaces__msg__UInt16__Sequence * array, size_t size);
+
+/// Finalize array of msg/UInt16 messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt16__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt16__Sequence__fini(example_interfaces__msg__UInt16__Sequence * array);
+
+/// Create array of msg/UInt16 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__UInt16__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt16__Sequence *
+example_interfaces__msg__UInt16__Sequence__create(size_t size);
+
+/// Destroy array of msg/UInt16 messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt16__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt16__Sequence__destroy(example_interfaces__msg__UInt16__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/u_int16__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/u_int16__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/UInt16.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT16__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT16__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__UInt16(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__UInt16(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, UInt16)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT16__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/u_int16__struct.h
+++ b/src/example_interfaces/msg/detail/u_int16__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/UInt16.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/UInt16 in the package example_interfaces.
+typedef struct example_interfaces__msg__UInt16
+{
+  uint16_t data;
+} example_interfaces__msg__UInt16;
+
+// Struct for a sequence of example_interfaces__msg__UInt16.
+typedef struct example_interfaces__msg__UInt16__Sequence
+{
+  example_interfaces__msg__UInt16 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__UInt16__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16__STRUCT_H_

--- a/src/example_interfaces/msg/detail/u_int16__type_support.h
+++ b/src/example_interfaces/msg/detail/u_int16__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/UInt16.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  UInt16
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/u_int16_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/u_int16_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/UInt16MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/u_int16_multi_array__struct.h"
+
+/// Initialize msg/UInt16MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__UInt16MultiArray
+ * )) before or use
+ * example_interfaces__msg__UInt16MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt16MultiArray__init(example_interfaces__msg__UInt16MultiArray * msg);
+
+/// Finalize msg/UInt16MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt16MultiArray__fini(example_interfaces__msg__UInt16MultiArray * msg);
+
+/// Create msg/UInt16MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__UInt16MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt16MultiArray *
+example_interfaces__msg__UInt16MultiArray__create();
+
+/// Destroy msg/UInt16MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__UInt16MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt16MultiArray__destroy(example_interfaces__msg__UInt16MultiArray * msg);
+
+
+/// Initialize array of msg/UInt16MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__UInt16MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt16MultiArray__Sequence__init(example_interfaces__msg__UInt16MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/UInt16MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt16MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt16MultiArray__Sequence__fini(example_interfaces__msg__UInt16MultiArray__Sequence * array);
+
+/// Create array of msg/UInt16MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__UInt16MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt16MultiArray__Sequence *
+example_interfaces__msg__UInt16MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/UInt16MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt16MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt16MultiArray__Sequence__destroy(example_interfaces__msg__UInt16MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/u_int16_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/u_int16_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/UInt16MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT16_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT16_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__UInt16MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__UInt16MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, UInt16MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT16_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/u_int16_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/u_int16_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/UInt16MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/UInt16MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__UInt16MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__uint16__Sequence data;
+} example_interfaces__msg__UInt16MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__UInt16MultiArray.
+typedef struct example_interfaces__msg__UInt16MultiArray__Sequence
+{
+  example_interfaces__msg__UInt16MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__UInt16MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/u_int16_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/u_int16_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/UInt16MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  UInt16MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT16_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/u_int32__functions.h
+++ b/src/example_interfaces/msg/detail/u_int32__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/UInt32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/u_int32__struct.h"
+
+/// Initialize msg/UInt32 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__UInt32
+ * )) before or use
+ * example_interfaces__msg__UInt32__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt32__init(example_interfaces__msg__UInt32 * msg);
+
+/// Finalize msg/UInt32 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt32__fini(example_interfaces__msg__UInt32 * msg);
+
+/// Create msg/UInt32 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__UInt32__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt32 *
+example_interfaces__msg__UInt32__create();
+
+/// Destroy msg/UInt32 message.
+/**
+ * It calls
+ * example_interfaces__msg__UInt32__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt32__destroy(example_interfaces__msg__UInt32 * msg);
+
+
+/// Initialize array of msg/UInt32 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__UInt32__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt32__Sequence__init(example_interfaces__msg__UInt32__Sequence * array, size_t size);
+
+/// Finalize array of msg/UInt32 messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt32__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt32__Sequence__fini(example_interfaces__msg__UInt32__Sequence * array);
+
+/// Create array of msg/UInt32 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__UInt32__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt32__Sequence *
+example_interfaces__msg__UInt32__Sequence__create(size_t size);
+
+/// Destroy array of msg/UInt32 messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt32__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt32__Sequence__destroy(example_interfaces__msg__UInt32__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/u_int32__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/u_int32__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/UInt32.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT32__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT32__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__UInt32(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__UInt32(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, UInt32)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT32__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/u_int32__struct.h
+++ b/src/example_interfaces/msg/detail/u_int32__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/UInt32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/UInt32 in the package example_interfaces.
+typedef struct example_interfaces__msg__UInt32
+{
+  uint32_t data;
+} example_interfaces__msg__UInt32;
+
+// Struct for a sequence of example_interfaces__msg__UInt32.
+typedef struct example_interfaces__msg__UInt32__Sequence
+{
+  example_interfaces__msg__UInt32 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__UInt32__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32__STRUCT_H_

--- a/src/example_interfaces/msg/detail/u_int32__type_support.h
+++ b/src/example_interfaces/msg/detail/u_int32__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/UInt32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  UInt32
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/u_int32_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/u_int32_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/UInt32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/u_int32_multi_array__struct.h"
+
+/// Initialize msg/UInt32MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__UInt32MultiArray
+ * )) before or use
+ * example_interfaces__msg__UInt32MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt32MultiArray__init(example_interfaces__msg__UInt32MultiArray * msg);
+
+/// Finalize msg/UInt32MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt32MultiArray__fini(example_interfaces__msg__UInt32MultiArray * msg);
+
+/// Create msg/UInt32MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__UInt32MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt32MultiArray *
+example_interfaces__msg__UInt32MultiArray__create();
+
+/// Destroy msg/UInt32MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__UInt32MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt32MultiArray__destroy(example_interfaces__msg__UInt32MultiArray * msg);
+
+
+/// Initialize array of msg/UInt32MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__UInt32MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt32MultiArray__Sequence__init(example_interfaces__msg__UInt32MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/UInt32MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt32MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt32MultiArray__Sequence__fini(example_interfaces__msg__UInt32MultiArray__Sequence * array);
+
+/// Create array of msg/UInt32MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__UInt32MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt32MultiArray__Sequence *
+example_interfaces__msg__UInt32MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/UInt32MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt32MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt32MultiArray__Sequence__destroy(example_interfaces__msg__UInt32MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/u_int32_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/u_int32_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/UInt32MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT32_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT32_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__UInt32MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__UInt32MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, UInt32MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT32_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/u_int32_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/u_int32_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/UInt32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/UInt32MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__UInt32MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__uint32__Sequence data;
+} example_interfaces__msg__UInt32MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__UInt32MultiArray.
+typedef struct example_interfaces__msg__UInt32MultiArray__Sequence
+{
+  example_interfaces__msg__UInt32MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__UInt32MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/u_int32_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/u_int32_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/UInt32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  UInt32MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT32_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/u_int64__functions.h
+++ b/src/example_interfaces/msg/detail/u_int64__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/UInt64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/u_int64__struct.h"
+
+/// Initialize msg/UInt64 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__UInt64
+ * )) before or use
+ * example_interfaces__msg__UInt64__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt64__init(example_interfaces__msg__UInt64 * msg);
+
+/// Finalize msg/UInt64 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt64__fini(example_interfaces__msg__UInt64 * msg);
+
+/// Create msg/UInt64 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__UInt64__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt64 *
+example_interfaces__msg__UInt64__create();
+
+/// Destroy msg/UInt64 message.
+/**
+ * It calls
+ * example_interfaces__msg__UInt64__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt64__destroy(example_interfaces__msg__UInt64 * msg);
+
+
+/// Initialize array of msg/UInt64 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__UInt64__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt64__Sequence__init(example_interfaces__msg__UInt64__Sequence * array, size_t size);
+
+/// Finalize array of msg/UInt64 messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt64__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt64__Sequence__fini(example_interfaces__msg__UInt64__Sequence * array);
+
+/// Create array of msg/UInt64 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__UInt64__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt64__Sequence *
+example_interfaces__msg__UInt64__Sequence__create(size_t size);
+
+/// Destroy array of msg/UInt64 messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt64__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt64__Sequence__destroy(example_interfaces__msg__UInt64__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/u_int64__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/u_int64__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/UInt64.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT64__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT64__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__UInt64(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__UInt64(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, UInt64)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT64__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/u_int64__struct.h
+++ b/src/example_interfaces/msg/detail/u_int64__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/UInt64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/UInt64 in the package example_interfaces.
+typedef struct example_interfaces__msg__UInt64
+{
+  uint64_t data;
+} example_interfaces__msg__UInt64;
+
+// Struct for a sequence of example_interfaces__msg__UInt64.
+typedef struct example_interfaces__msg__UInt64__Sequence
+{
+  example_interfaces__msg__UInt64 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__UInt64__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64__STRUCT_H_

--- a/src/example_interfaces/msg/detail/u_int64__type_support.h
+++ b/src/example_interfaces/msg/detail/u_int64__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/UInt64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  UInt64
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/u_int64_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/u_int64_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/UInt64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/u_int64_multi_array__struct.h"
+
+/// Initialize msg/UInt64MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__UInt64MultiArray
+ * )) before or use
+ * example_interfaces__msg__UInt64MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt64MultiArray__init(example_interfaces__msg__UInt64MultiArray * msg);
+
+/// Finalize msg/UInt64MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt64MultiArray__fini(example_interfaces__msg__UInt64MultiArray * msg);
+
+/// Create msg/UInt64MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__UInt64MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt64MultiArray *
+example_interfaces__msg__UInt64MultiArray__create();
+
+/// Destroy msg/UInt64MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__UInt64MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt64MultiArray__destroy(example_interfaces__msg__UInt64MultiArray * msg);
+
+
+/// Initialize array of msg/UInt64MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__UInt64MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt64MultiArray__Sequence__init(example_interfaces__msg__UInt64MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/UInt64MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt64MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt64MultiArray__Sequence__fini(example_interfaces__msg__UInt64MultiArray__Sequence * array);
+
+/// Create array of msg/UInt64MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__UInt64MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt64MultiArray__Sequence *
+example_interfaces__msg__UInt64MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/UInt64MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt64MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt64MultiArray__Sequence__destroy(example_interfaces__msg__UInt64MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/u_int64_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/u_int64_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/UInt64MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT64_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT64_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__UInt64MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__UInt64MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, UInt64MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT64_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/u_int64_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/u_int64_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/UInt64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/UInt64MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__UInt64MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__uint64__Sequence data;
+} example_interfaces__msg__UInt64MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__UInt64MultiArray.
+typedef struct example_interfaces__msg__UInt64MultiArray__Sequence
+{
+  example_interfaces__msg__UInt64MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__UInt64MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/u_int64_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/u_int64_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/UInt64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  UInt64MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT64_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/u_int8__functions.h
+++ b/src/example_interfaces/msg/detail/u_int8__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/UInt8.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/u_int8__struct.h"
+
+/// Initialize msg/UInt8 message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__UInt8
+ * )) before or use
+ * example_interfaces__msg__UInt8__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt8__init(example_interfaces__msg__UInt8 * msg);
+
+/// Finalize msg/UInt8 message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt8__fini(example_interfaces__msg__UInt8 * msg);
+
+/// Create msg/UInt8 message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__UInt8__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt8 *
+example_interfaces__msg__UInt8__create();
+
+/// Destroy msg/UInt8 message.
+/**
+ * It calls
+ * example_interfaces__msg__UInt8__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt8__destroy(example_interfaces__msg__UInt8 * msg);
+
+
+/// Initialize array of msg/UInt8 messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__UInt8__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt8__Sequence__init(example_interfaces__msg__UInt8__Sequence * array, size_t size);
+
+/// Finalize array of msg/UInt8 messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt8__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt8__Sequence__fini(example_interfaces__msg__UInt8__Sequence * array);
+
+/// Create array of msg/UInt8 messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__UInt8__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt8__Sequence *
+example_interfaces__msg__UInt8__Sequence__create(size_t size);
+
+/// Destroy array of msg/UInt8 messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt8__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt8__Sequence__destroy(example_interfaces__msg__UInt8__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/u_int8__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/u_int8__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/UInt8.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT8__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT8__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__UInt8(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__UInt8(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, UInt8)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT8__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/u_int8__struct.h
+++ b/src/example_interfaces/msg/detail/u_int8__struct.h
@@ -1,0 +1,40 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/UInt8.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in msg/UInt8 in the package example_interfaces.
+typedef struct example_interfaces__msg__UInt8
+{
+  uint8_t data;
+} example_interfaces__msg__UInt8;
+
+// Struct for a sequence of example_interfaces__msg__UInt8.
+typedef struct example_interfaces__msg__UInt8__Sequence
+{
+  example_interfaces__msg__UInt8 * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__UInt8__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8__STRUCT_H_

--- a/src/example_interfaces/msg/detail/u_int8__type_support.h
+++ b/src/example_interfaces/msg/detail/u_int8__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/UInt8.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  UInt8
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/u_int8_multi_array__functions.h
+++ b/src/example_interfaces/msg/detail/u_int8_multi_array__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/UInt8MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8_MULTI_ARRAY__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8_MULTI_ARRAY__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/u_int8_multi_array__struct.h"
+
+/// Initialize msg/UInt8MultiArray message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__UInt8MultiArray
+ * )) before or use
+ * example_interfaces__msg__UInt8MultiArray__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt8MultiArray__init(example_interfaces__msg__UInt8MultiArray * msg);
+
+/// Finalize msg/UInt8MultiArray message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt8MultiArray__fini(example_interfaces__msg__UInt8MultiArray * msg);
+
+/// Create msg/UInt8MultiArray message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__UInt8MultiArray__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt8MultiArray *
+example_interfaces__msg__UInt8MultiArray__create();
+
+/// Destroy msg/UInt8MultiArray message.
+/**
+ * It calls
+ * example_interfaces__msg__UInt8MultiArray__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt8MultiArray__destroy(example_interfaces__msg__UInt8MultiArray * msg);
+
+
+/// Initialize array of msg/UInt8MultiArray messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__UInt8MultiArray__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__UInt8MultiArray__Sequence__init(example_interfaces__msg__UInt8MultiArray__Sequence * array, size_t size);
+
+/// Finalize array of msg/UInt8MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt8MultiArray__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt8MultiArray__Sequence__fini(example_interfaces__msg__UInt8MultiArray__Sequence * array);
+
+/// Create array of msg/UInt8MultiArray messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__UInt8MultiArray__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__UInt8MultiArray__Sequence *
+example_interfaces__msg__UInt8MultiArray__Sequence__create(size_t size);
+
+/// Destroy array of msg/UInt8MultiArray messages.
+/**
+ * It calls
+ * example_interfaces__msg__UInt8MultiArray__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__UInt8MultiArray__Sequence__destroy(example_interfaces__msg__UInt8MultiArray__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8_MULTI_ARRAY__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/u_int8_multi_array__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/u_int8_multi_array__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/UInt8MultiArray.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT8_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT8_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__UInt8MultiArray(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__UInt8MultiArray(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, UInt8MultiArray)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT8_MULTI_ARRAY__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/u_int8_multi_array__struct.h
+++ b/src/example_interfaces/msg/detail/u_int8_multi_array__struct.h
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/UInt8MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8_MULTI_ARRAY__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8_MULTI_ARRAY__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'layout'
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+// Member 'data'
+#include "rosidl_runtime_c/primitives_sequence.h"
+
+// Struct defined in msg/UInt8MultiArray in the package example_interfaces.
+typedef struct example_interfaces__msg__UInt8MultiArray
+{
+  example_interfaces__msg__MultiArrayLayout layout;
+  rosidl_runtime_c__uint8__Sequence data;
+} example_interfaces__msg__UInt8MultiArray;
+
+// Struct for a sequence of example_interfaces__msg__UInt8MultiArray.
+typedef struct example_interfaces__msg__UInt8MultiArray__Sequence
+{
+  example_interfaces__msg__UInt8MultiArray * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__UInt8MultiArray__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8_MULTI_ARRAY__STRUCT_H_

--- a/src/example_interfaces/msg/detail/u_int8_multi_array__type_support.h
+++ b/src/example_interfaces/msg/detail/u_int8_multi_array__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/UInt8MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8_MULTI_ARRAY__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8_MULTI_ARRAY__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  UInt8MultiArray
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__U_INT8_MULTI_ARRAY__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/detail/w_string__functions.h
+++ b/src/example_interfaces/msg/detail/w_string__functions.h
@@ -1,0 +1,124 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:msg/WString.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__W_STRING__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__W_STRING__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/msg/detail/w_string__struct.h"
+
+/// Initialize msg/WString message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__msg__WString
+ * )) before or use
+ * example_interfaces__msg__WString__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__WString__init(example_interfaces__msg__WString * msg);
+
+/// Finalize msg/WString message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__WString__fini(example_interfaces__msg__WString * msg);
+
+/// Create msg/WString message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__msg__WString__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__WString *
+example_interfaces__msg__WString__create();
+
+/// Destroy msg/WString message.
+/**
+ * It calls
+ * example_interfaces__msg__WString__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__WString__destroy(example_interfaces__msg__WString * msg);
+
+
+/// Initialize array of msg/WString messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__msg__WString__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__msg__WString__Sequence__init(example_interfaces__msg__WString__Sequence * array, size_t size);
+
+/// Finalize array of msg/WString messages.
+/**
+ * It calls
+ * example_interfaces__msg__WString__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__WString__Sequence__fini(example_interfaces__msg__WString__Sequence * array);
+
+/// Create array of msg/WString messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__msg__WString__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__msg__WString__Sequence *
+example_interfaces__msg__WString__Sequence__create(size_t size);
+
+/// Destroy array of msg/WString messages.
+/**
+ * It calls
+ * example_interfaces__msg__WString__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__msg__WString__Sequence__destroy(example_interfaces__msg__WString__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__W_STRING__FUNCTIONS_H_

--- a/src/example_interfaces/msg/detail/w_string__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/msg/detail/w_string__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,39 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:msg/WString.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__MSG__W_STRING__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__MSG__W_STRING__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__msg__WString(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__msg__WString(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, msg, WString)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // EXAMPLE_INTERFACES__MSG__W_STRING__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/msg/detail/w_string__struct.h
+++ b/src/example_interfaces/msg/detail/w_string__struct.h
@@ -1,0 +1,44 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:msg/WString.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__W_STRING__STRUCT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__W_STRING__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'data'
+#include "rosidl_runtime_c/u16string.h"
+
+// Struct defined in msg/WString in the package example_interfaces.
+typedef struct example_interfaces__msg__WString
+{
+  rosidl_runtime_c__U16String data;
+} example_interfaces__msg__WString;
+
+// Struct for a sequence of example_interfaces__msg__WString.
+typedef struct example_interfaces__msg__WString__Sequence
+{
+  example_interfaces__msg__WString * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__msg__WString__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__W_STRING__STRUCT_H_

--- a/src/example_interfaces/msg/detail/w_string__type_support.h
+++ b/src/example_interfaces/msg/detail/w_string__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:msg/WString.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__DETAIL__W_STRING__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__MSG__DETAIL__W_STRING__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  msg,
+  WString
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__DETAIL__W_STRING__TYPE_SUPPORT_H_

--- a/src/example_interfaces/msg/empty.h
+++ b/src/example_interfaces/msg/empty.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Empty.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__EMPTY_H_
+#define EXAMPLE_INTERFACES__MSG__EMPTY_H_
+
+#include "example_interfaces/msg/detail/empty__struct.h"
+#include "example_interfaces/msg/detail/empty__functions.h"
+#include "example_interfaces/msg/detail/empty__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__EMPTY_H_

--- a/src/example_interfaces/msg/float32.h
+++ b/src/example_interfaces/msg/float32.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Float32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__FLOAT32_H_
+#define EXAMPLE_INTERFACES__MSG__FLOAT32_H_
+
+#include "example_interfaces/msg/detail/float32__struct.h"
+#include "example_interfaces/msg/detail/float32__functions.h"
+#include "example_interfaces/msg/detail/float32__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__FLOAT32_H_

--- a/src/example_interfaces/msg/float32_multi_array.h
+++ b/src/example_interfaces/msg/float32_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Float32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__FLOAT32_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__FLOAT32_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/float32_multi_array__struct.h"
+#include "example_interfaces/msg/detail/float32_multi_array__functions.h"
+#include "example_interfaces/msg/detail/float32_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__FLOAT32_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/float64.h
+++ b/src/example_interfaces/msg/float64.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Float64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__FLOAT64_H_
+#define EXAMPLE_INTERFACES__MSG__FLOAT64_H_
+
+#include "example_interfaces/msg/detail/float64__struct.h"
+#include "example_interfaces/msg/detail/float64__functions.h"
+#include "example_interfaces/msg/detail/float64__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__FLOAT64_H_

--- a/src/example_interfaces/msg/float64_multi_array.h
+++ b/src/example_interfaces/msg/float64_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Float64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__FLOAT64_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__FLOAT64_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/float64_multi_array__struct.h"
+#include "example_interfaces/msg/detail/float64_multi_array__functions.h"
+#include "example_interfaces/msg/detail/float64_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__FLOAT64_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/int16.h
+++ b/src/example_interfaces/msg/int16.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Int16.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__INT16_H_
+#define EXAMPLE_INTERFACES__MSG__INT16_H_
+
+#include "example_interfaces/msg/detail/int16__struct.h"
+#include "example_interfaces/msg/detail/int16__functions.h"
+#include "example_interfaces/msg/detail/int16__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT16_H_

--- a/src/example_interfaces/msg/int16_multi_array.h
+++ b/src/example_interfaces/msg/int16_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Int16MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__INT16_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__INT16_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/int16_multi_array__struct.h"
+#include "example_interfaces/msg/detail/int16_multi_array__functions.h"
+#include "example_interfaces/msg/detail/int16_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT16_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/int32.h
+++ b/src/example_interfaces/msg/int32.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Int32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__INT32_H_
+#define EXAMPLE_INTERFACES__MSG__INT32_H_
+
+#include "example_interfaces/msg/detail/int32__struct.h"
+#include "example_interfaces/msg/detail/int32__functions.h"
+#include "example_interfaces/msg/detail/int32__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT32_H_

--- a/src/example_interfaces/msg/int32_multi_array.h
+++ b/src/example_interfaces/msg/int32_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Int32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__INT32_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__INT32_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/int32_multi_array__struct.h"
+#include "example_interfaces/msg/detail/int32_multi_array__functions.h"
+#include "example_interfaces/msg/detail/int32_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT32_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/int64.h
+++ b/src/example_interfaces/msg/int64.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Int64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__INT64_H_
+#define EXAMPLE_INTERFACES__MSG__INT64_H_
+
+#include "example_interfaces/msg/detail/int64__struct.h"
+#include "example_interfaces/msg/detail/int64__functions.h"
+#include "example_interfaces/msg/detail/int64__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT64_H_

--- a/src/example_interfaces/msg/int64_multi_array.h
+++ b/src/example_interfaces/msg/int64_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Int64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__INT64_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__INT64_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/int64_multi_array__struct.h"
+#include "example_interfaces/msg/detail/int64_multi_array__functions.h"
+#include "example_interfaces/msg/detail/int64_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT64_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/int8.h
+++ b/src/example_interfaces/msg/int8.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Int8.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__INT8_H_
+#define EXAMPLE_INTERFACES__MSG__INT8_H_
+
+#include "example_interfaces/msg/detail/int8__struct.h"
+#include "example_interfaces/msg/detail/int8__functions.h"
+#include "example_interfaces/msg/detail/int8__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT8_H_

--- a/src/example_interfaces/msg/int8_multi_array.h
+++ b/src/example_interfaces/msg/int8_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/Int8MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__INT8_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__INT8_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/int8_multi_array__struct.h"
+#include "example_interfaces/msg/detail/int8_multi_array__functions.h"
+#include "example_interfaces/msg/detail/int8_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__INT8_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/multi_array_dimension.h
+++ b/src/example_interfaces/msg/multi_array_dimension.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/MultiArrayDimension.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_DIMENSION_H_
+#define EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_DIMENSION_H_
+
+#include "example_interfaces/msg/detail/multi_array_dimension__struct.h"
+#include "example_interfaces/msg/detail/multi_array_dimension__functions.h"
+#include "example_interfaces/msg/detail/multi_array_dimension__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_DIMENSION_H_

--- a/src/example_interfaces/msg/multi_array_layout.h
+++ b/src/example_interfaces/msg/multi_array_layout.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/MultiArrayLayout.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_LAYOUT_H_
+#define EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_LAYOUT_H_
+
+#include "example_interfaces/msg/detail/multi_array_layout__struct.h"
+#include "example_interfaces/msg/detail/multi_array_layout__functions.h"
+#include "example_interfaces/msg/detail/multi_array_layout__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__MULTI_ARRAY_LAYOUT_H_

--- a/src/example_interfaces/msg/rosidl_generator_c__visibility_control.h
+++ b/src/example_interfaces/msg/rosidl_generator_c__visibility_control.h
@@ -1,0 +1,42 @@
+// generated from rosidl_generator_c/resource/rosidl_generator_c__visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
+#define EXAMPLE_INTERFACES__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_GENERATOR_C_EXPORT_example_interfaces __attribute__ ((dllexport))
+    #define ROSIDL_GENERATOR_C_IMPORT_example_interfaces __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_GENERATOR_C_EXPORT_example_interfaces __declspec(dllexport)
+    #define ROSIDL_GENERATOR_C_IMPORT_example_interfaces __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_GENERATOR_C_BUILDING_DLL_example_interfaces
+    #define ROSIDL_GENERATOR_C_PUBLIC_example_interfaces ROSIDL_GENERATOR_C_EXPORT_example_interfaces
+  #else
+    #define ROSIDL_GENERATOR_C_PUBLIC_example_interfaces ROSIDL_GENERATOR_C_IMPORT_example_interfaces
+  #endif
+#else
+  #define ROSIDL_GENERATOR_C_EXPORT_example_interfaces __attribute__ ((visibility("default")))
+  #define ROSIDL_GENERATOR_C_IMPORT_example_interfaces
+  #if __GNUC__ >= 4
+    #define ROSIDL_GENERATOR_C_PUBLIC_example_interfaces __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_

--- a/src/example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h
+++ b/src/example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h
@@ -1,0 +1,43 @@
+// generated from
+// rosidl_typesupport_microxrcedds_c/resource/rosidl_typesupport_microxrcedds_c__visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C__VISIBILITY_CONTROL_H_
+#define EXAMPLE_INTERFACES__MSG__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C__VISIBILITY_CONTROL_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_EXPORT_example_interfaces __attribute__ ((dllexport))
+    #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_IMPORT_example_interfaces __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_EXPORT_example_interfaces __declspec(dllexport)
+    #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_IMPORT_example_interfaces __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_BUILDING_DLL_example_interfaces
+    #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_EXPORT_example_interfaces
+  #else
+    #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_IMPORT_example_interfaces
+  #endif
+#else
+  #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_EXPORT_example_interfaces __attribute__ ((visibility("default")))
+  #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_IMPORT_example_interfaces
+  #if __GNUC__ >= 4
+    #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+  #endif
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__MSG__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C__VISIBILITY_CONTROL_H_

--- a/src/example_interfaces/msg/string.h
+++ b/src/example_interfaces/msg/string.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/String.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__STRING_H_
+#define EXAMPLE_INTERFACES__MSG__STRING_H_
+
+#include "example_interfaces/msg/detail/string__struct.h"
+#include "example_interfaces/msg/detail/string__functions.h"
+#include "example_interfaces/msg/detail/string__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__STRING_H_

--- a/src/example_interfaces/msg/u_int16.h
+++ b/src/example_interfaces/msg/u_int16.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/UInt16.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT16_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT16_H_
+
+#include "example_interfaces/msg/detail/u_int16__struct.h"
+#include "example_interfaces/msg/detail/u_int16__functions.h"
+#include "example_interfaces/msg/detail/u_int16__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT16_H_

--- a/src/example_interfaces/msg/u_int16_multi_array.h
+++ b/src/example_interfaces/msg/u_int16_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/UInt16MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT16_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT16_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/u_int16_multi_array__struct.h"
+#include "example_interfaces/msg/detail/u_int16_multi_array__functions.h"
+#include "example_interfaces/msg/detail/u_int16_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT16_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/u_int32.h
+++ b/src/example_interfaces/msg/u_int32.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/UInt32.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT32_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT32_H_
+
+#include "example_interfaces/msg/detail/u_int32__struct.h"
+#include "example_interfaces/msg/detail/u_int32__functions.h"
+#include "example_interfaces/msg/detail/u_int32__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT32_H_

--- a/src/example_interfaces/msg/u_int32_multi_array.h
+++ b/src/example_interfaces/msg/u_int32_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/UInt32MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT32_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT32_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/u_int32_multi_array__struct.h"
+#include "example_interfaces/msg/detail/u_int32_multi_array__functions.h"
+#include "example_interfaces/msg/detail/u_int32_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT32_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/u_int64.h
+++ b/src/example_interfaces/msg/u_int64.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/UInt64.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT64_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT64_H_
+
+#include "example_interfaces/msg/detail/u_int64__struct.h"
+#include "example_interfaces/msg/detail/u_int64__functions.h"
+#include "example_interfaces/msg/detail/u_int64__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT64_H_

--- a/src/example_interfaces/msg/u_int64_multi_array.h
+++ b/src/example_interfaces/msg/u_int64_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/UInt64MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT64_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT64_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/u_int64_multi_array__struct.h"
+#include "example_interfaces/msg/detail/u_int64_multi_array__functions.h"
+#include "example_interfaces/msg/detail/u_int64_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT64_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/u_int8.h
+++ b/src/example_interfaces/msg/u_int8.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/UInt8.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT8_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT8_H_
+
+#include "example_interfaces/msg/detail/u_int8__struct.h"
+#include "example_interfaces/msg/detail/u_int8__functions.h"
+#include "example_interfaces/msg/detail/u_int8__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT8_H_

--- a/src/example_interfaces/msg/u_int8_multi_array.h
+++ b/src/example_interfaces/msg/u_int8_multi_array.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/UInt8MultiArray.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__U_INT8_MULTI_ARRAY_H_
+#define EXAMPLE_INTERFACES__MSG__U_INT8_MULTI_ARRAY_H_
+
+#include "example_interfaces/msg/detail/u_int8_multi_array__struct.h"
+#include "example_interfaces/msg/detail/u_int8_multi_array__functions.h"
+#include "example_interfaces/msg/detail/u_int8_multi_array__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__U_INT8_MULTI_ARRAY_H_

--- a/src/example_interfaces/msg/w_string.h
+++ b/src/example_interfaces/msg/w_string.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:msg/WString.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__MSG__W_STRING_H_
+#define EXAMPLE_INTERFACES__MSG__W_STRING_H_
+
+#include "example_interfaces/msg/detail/w_string__struct.h"
+#include "example_interfaces/msg/detail/w_string__functions.h"
+#include "example_interfaces/msg/detail/w_string__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__MSG__W_STRING_H_

--- a/src/example_interfaces/srv/add_two_ints.h
+++ b/src/example_interfaces/srv/add_two_ints.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:srv/AddTwoInts.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__ADD_TWO_INTS_H_
+#define EXAMPLE_INTERFACES__SRV__ADD_TWO_INTS_H_
+
+#include "example_interfaces/srv/detail/add_two_ints__struct.h"
+#include "example_interfaces/srv/detail/add_two_ints__functions.h"
+#include "example_interfaces/srv/detail/add_two_ints__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__SRV__ADD_TWO_INTS_H_

--- a/src/example_interfaces/srv/detail/add_two_ints__functions.h
+++ b/src/example_interfaces/srv/detail/add_two_ints__functions.h
@@ -1,0 +1,223 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:srv/AddTwoInts.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__DETAIL__ADD_TWO_INTS__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__SRV__DETAIL__ADD_TWO_INTS__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/srv/detail/add_two_ints__struct.h"
+
+/// Initialize srv/AddTwoInts message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__srv__AddTwoInts_Request
+ * )) before or use
+ * example_interfaces__srv__AddTwoInts_Request__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__AddTwoInts_Request__init(example_interfaces__srv__AddTwoInts_Request * msg);
+
+/// Finalize srv/AddTwoInts message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__AddTwoInts_Request__fini(example_interfaces__srv__AddTwoInts_Request * msg);
+
+/// Create srv/AddTwoInts message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__srv__AddTwoInts_Request__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__AddTwoInts_Request *
+example_interfaces__srv__AddTwoInts_Request__create();
+
+/// Destroy srv/AddTwoInts message.
+/**
+ * It calls
+ * example_interfaces__srv__AddTwoInts_Request__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__AddTwoInts_Request__destroy(example_interfaces__srv__AddTwoInts_Request * msg);
+
+
+/// Initialize array of srv/AddTwoInts messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__srv__AddTwoInts_Request__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__AddTwoInts_Request__Sequence__init(example_interfaces__srv__AddTwoInts_Request__Sequence * array, size_t size);
+
+/// Finalize array of srv/AddTwoInts messages.
+/**
+ * It calls
+ * example_interfaces__srv__AddTwoInts_Request__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__AddTwoInts_Request__Sequence__fini(example_interfaces__srv__AddTwoInts_Request__Sequence * array);
+
+/// Create array of srv/AddTwoInts messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__srv__AddTwoInts_Request__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__AddTwoInts_Request__Sequence *
+example_interfaces__srv__AddTwoInts_Request__Sequence__create(size_t size);
+
+/// Destroy array of srv/AddTwoInts messages.
+/**
+ * It calls
+ * example_interfaces__srv__AddTwoInts_Request__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__AddTwoInts_Request__Sequence__destroy(example_interfaces__srv__AddTwoInts_Request__Sequence * array);
+
+/// Initialize srv/AddTwoInts message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__srv__AddTwoInts_Response
+ * )) before or use
+ * example_interfaces__srv__AddTwoInts_Response__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__AddTwoInts_Response__init(example_interfaces__srv__AddTwoInts_Response * msg);
+
+/// Finalize srv/AddTwoInts message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__AddTwoInts_Response__fini(example_interfaces__srv__AddTwoInts_Response * msg);
+
+/// Create srv/AddTwoInts message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__srv__AddTwoInts_Response__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__AddTwoInts_Response *
+example_interfaces__srv__AddTwoInts_Response__create();
+
+/// Destroy srv/AddTwoInts message.
+/**
+ * It calls
+ * example_interfaces__srv__AddTwoInts_Response__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__AddTwoInts_Response__destroy(example_interfaces__srv__AddTwoInts_Response * msg);
+
+
+/// Initialize array of srv/AddTwoInts messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__srv__AddTwoInts_Response__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__AddTwoInts_Response__Sequence__init(example_interfaces__srv__AddTwoInts_Response__Sequence * array, size_t size);
+
+/// Finalize array of srv/AddTwoInts messages.
+/**
+ * It calls
+ * example_interfaces__srv__AddTwoInts_Response__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__AddTwoInts_Response__Sequence__fini(example_interfaces__srv__AddTwoInts_Response__Sequence * array);
+
+/// Create array of srv/AddTwoInts messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__srv__AddTwoInts_Response__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__AddTwoInts_Response__Sequence *
+example_interfaces__srv__AddTwoInts_Response__Sequence__create(size_t size);
+
+/// Destroy array of srv/AddTwoInts messages.
+/**
+ * It calls
+ * example_interfaces__srv__AddTwoInts_Response__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__AddTwoInts_Response__Sequence__destroy(example_interfaces__srv__AddTwoInts_Response__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__DETAIL__ADD_TWO_INTS__FUNCTIONS_H_

--- a/src/example_interfaces/srv/detail/add_two_ints__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/srv/detail/add_two_ints__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,95 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:srv/AddTwoInts.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__SRV__ADD_TWO_INTS__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__SRV__ADD_TWO_INTS__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__srv__AddTwoInts_Request(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__srv__AddTwoInts_Request(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, srv, AddTwoInts_Request)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__srv__AddTwoInts_Response(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__srv__AddTwoInts_Response(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, srv, AddTwoInts_Response)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#include "rosidl_runtime_c/service_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, srv, AddTwoInts)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__ADD_TWO_INTS__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/srv/detail/add_two_ints__struct.h
+++ b/src/example_interfaces/srv/detail/add_two_ints__struct.h
@@ -1,0 +1,60 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:srv/AddTwoInts.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__DETAIL__ADD_TWO_INTS__STRUCT_H_
+#define EXAMPLE_INTERFACES__SRV__DETAIL__ADD_TWO_INTS__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in srv/AddTwoInts in the package example_interfaces.
+typedef struct example_interfaces__srv__AddTwoInts_Request
+{
+  int64_t a;
+  int64_t b;
+} example_interfaces__srv__AddTwoInts_Request;
+
+// Struct for a sequence of example_interfaces__srv__AddTwoInts_Request.
+typedef struct example_interfaces__srv__AddTwoInts_Request__Sequence
+{
+  example_interfaces__srv__AddTwoInts_Request * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__srv__AddTwoInts_Request__Sequence;
+
+
+// Constants defined in the message
+
+// Struct defined in srv/AddTwoInts in the package example_interfaces.
+typedef struct example_interfaces__srv__AddTwoInts_Response
+{
+  int64_t sum;
+} example_interfaces__srv__AddTwoInts_Response;
+
+// Struct for a sequence of example_interfaces__srv__AddTwoInts_Response.
+typedef struct example_interfaces__srv__AddTwoInts_Response__Sequence
+{
+  example_interfaces__srv__AddTwoInts_Response * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__srv__AddTwoInts_Response__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__DETAIL__ADD_TWO_INTS__STRUCT_H_

--- a/src/example_interfaces/srv/detail/add_two_ints__type_support.h
+++ b/src/example_interfaces/srv/detail/add_two_ints__type_support.h
@@ -1,0 +1,58 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:srv/AddTwoInts.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__DETAIL__ADD_TWO_INTS__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__SRV__DETAIL__ADD_TWO_INTS__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  srv,
+  AddTwoInts_Request
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  srv,
+  AddTwoInts_Response
+)();
+
+#include "rosidl_runtime_c/service_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  srv,
+  AddTwoInts
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__DETAIL__ADD_TWO_INTS__TYPE_SUPPORT_H_

--- a/src/example_interfaces/srv/detail/set_bool__functions.h
+++ b/src/example_interfaces/srv/detail/set_bool__functions.h
@@ -1,0 +1,223 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:srv/SetBool.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__DETAIL__SET_BOOL__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__SRV__DETAIL__SET_BOOL__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/srv/detail/set_bool__struct.h"
+
+/// Initialize srv/SetBool message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__srv__SetBool_Request
+ * )) before or use
+ * example_interfaces__srv__SetBool_Request__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__SetBool_Request__init(example_interfaces__srv__SetBool_Request * msg);
+
+/// Finalize srv/SetBool message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__SetBool_Request__fini(example_interfaces__srv__SetBool_Request * msg);
+
+/// Create srv/SetBool message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__srv__SetBool_Request__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__SetBool_Request *
+example_interfaces__srv__SetBool_Request__create();
+
+/// Destroy srv/SetBool message.
+/**
+ * It calls
+ * example_interfaces__srv__SetBool_Request__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__SetBool_Request__destroy(example_interfaces__srv__SetBool_Request * msg);
+
+
+/// Initialize array of srv/SetBool messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__srv__SetBool_Request__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__SetBool_Request__Sequence__init(example_interfaces__srv__SetBool_Request__Sequence * array, size_t size);
+
+/// Finalize array of srv/SetBool messages.
+/**
+ * It calls
+ * example_interfaces__srv__SetBool_Request__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__SetBool_Request__Sequence__fini(example_interfaces__srv__SetBool_Request__Sequence * array);
+
+/// Create array of srv/SetBool messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__srv__SetBool_Request__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__SetBool_Request__Sequence *
+example_interfaces__srv__SetBool_Request__Sequence__create(size_t size);
+
+/// Destroy array of srv/SetBool messages.
+/**
+ * It calls
+ * example_interfaces__srv__SetBool_Request__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__SetBool_Request__Sequence__destroy(example_interfaces__srv__SetBool_Request__Sequence * array);
+
+/// Initialize srv/SetBool message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__srv__SetBool_Response
+ * )) before or use
+ * example_interfaces__srv__SetBool_Response__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__SetBool_Response__init(example_interfaces__srv__SetBool_Response * msg);
+
+/// Finalize srv/SetBool message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__SetBool_Response__fini(example_interfaces__srv__SetBool_Response * msg);
+
+/// Create srv/SetBool message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__srv__SetBool_Response__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__SetBool_Response *
+example_interfaces__srv__SetBool_Response__create();
+
+/// Destroy srv/SetBool message.
+/**
+ * It calls
+ * example_interfaces__srv__SetBool_Response__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__SetBool_Response__destroy(example_interfaces__srv__SetBool_Response * msg);
+
+
+/// Initialize array of srv/SetBool messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__srv__SetBool_Response__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__SetBool_Response__Sequence__init(example_interfaces__srv__SetBool_Response__Sequence * array, size_t size);
+
+/// Finalize array of srv/SetBool messages.
+/**
+ * It calls
+ * example_interfaces__srv__SetBool_Response__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__SetBool_Response__Sequence__fini(example_interfaces__srv__SetBool_Response__Sequence * array);
+
+/// Create array of srv/SetBool messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__srv__SetBool_Response__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__SetBool_Response__Sequence *
+example_interfaces__srv__SetBool_Response__Sequence__create(size_t size);
+
+/// Destroy array of srv/SetBool messages.
+/**
+ * It calls
+ * example_interfaces__srv__SetBool_Response__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__SetBool_Response__Sequence__destroy(example_interfaces__srv__SetBool_Response__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__DETAIL__SET_BOOL__FUNCTIONS_H_

--- a/src/example_interfaces/srv/detail/set_bool__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/srv/detail/set_bool__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,95 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:srv/SetBool.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__SRV__SET_BOOL__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__SRV__SET_BOOL__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__srv__SetBool_Request(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__srv__SetBool_Request(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, srv, SetBool_Request)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__srv__SetBool_Response(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__srv__SetBool_Response(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, srv, SetBool_Response)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#include "rosidl_runtime_c/service_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, srv, SetBool)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__SET_BOOL__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/srv/detail/set_bool__struct.h
+++ b/src/example_interfaces/srv/detail/set_bool__struct.h
@@ -1,0 +1,64 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:srv/SetBool.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__DETAIL__SET_BOOL__STRUCT_H_
+#define EXAMPLE_INTERFACES__SRV__DETAIL__SET_BOOL__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in srv/SetBool in the package example_interfaces.
+typedef struct example_interfaces__srv__SetBool_Request
+{
+  bool data;
+} example_interfaces__srv__SetBool_Request;
+
+// Struct for a sequence of example_interfaces__srv__SetBool_Request.
+typedef struct example_interfaces__srv__SetBool_Request__Sequence
+{
+  example_interfaces__srv__SetBool_Request * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__srv__SetBool_Request__Sequence;
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'message'
+#include "rosidl_runtime_c/string.h"
+
+// Struct defined in srv/SetBool in the package example_interfaces.
+typedef struct example_interfaces__srv__SetBool_Response
+{
+  bool success;
+  rosidl_runtime_c__String message;
+} example_interfaces__srv__SetBool_Response;
+
+// Struct for a sequence of example_interfaces__srv__SetBool_Response.
+typedef struct example_interfaces__srv__SetBool_Response__Sequence
+{
+  example_interfaces__srv__SetBool_Response * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__srv__SetBool_Response__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__DETAIL__SET_BOOL__STRUCT_H_

--- a/src/example_interfaces/srv/detail/set_bool__type_support.h
+++ b/src/example_interfaces/srv/detail/set_bool__type_support.h
@@ -1,0 +1,58 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:srv/SetBool.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__DETAIL__SET_BOOL__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__SRV__DETAIL__SET_BOOL__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  srv,
+  SetBool_Request
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  srv,
+  SetBool_Response
+)();
+
+#include "rosidl_runtime_c/service_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  srv,
+  SetBool
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__DETAIL__SET_BOOL__TYPE_SUPPORT_H_

--- a/src/example_interfaces/srv/detail/trigger__functions.h
+++ b/src/example_interfaces/srv/detail/trigger__functions.h
@@ -1,0 +1,223 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from example_interfaces:srv/Trigger.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__DETAIL__TRIGGER__FUNCTIONS_H_
+#define EXAMPLE_INTERFACES__SRV__DETAIL__TRIGGER__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "example_interfaces/srv/detail/trigger__struct.h"
+
+/// Initialize srv/Trigger message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__srv__Trigger_Request
+ * )) before or use
+ * example_interfaces__srv__Trigger_Request__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__Trigger_Request__init(example_interfaces__srv__Trigger_Request * msg);
+
+/// Finalize srv/Trigger message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__Trigger_Request__fini(example_interfaces__srv__Trigger_Request * msg);
+
+/// Create srv/Trigger message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__srv__Trigger_Request__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__Trigger_Request *
+example_interfaces__srv__Trigger_Request__create();
+
+/// Destroy srv/Trigger message.
+/**
+ * It calls
+ * example_interfaces__srv__Trigger_Request__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__Trigger_Request__destroy(example_interfaces__srv__Trigger_Request * msg);
+
+
+/// Initialize array of srv/Trigger messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__srv__Trigger_Request__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__Trigger_Request__Sequence__init(example_interfaces__srv__Trigger_Request__Sequence * array, size_t size);
+
+/// Finalize array of srv/Trigger messages.
+/**
+ * It calls
+ * example_interfaces__srv__Trigger_Request__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__Trigger_Request__Sequence__fini(example_interfaces__srv__Trigger_Request__Sequence * array);
+
+/// Create array of srv/Trigger messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__srv__Trigger_Request__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__Trigger_Request__Sequence *
+example_interfaces__srv__Trigger_Request__Sequence__create(size_t size);
+
+/// Destroy array of srv/Trigger messages.
+/**
+ * It calls
+ * example_interfaces__srv__Trigger_Request__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__Trigger_Request__Sequence__destroy(example_interfaces__srv__Trigger_Request__Sequence * array);
+
+/// Initialize srv/Trigger message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * example_interfaces__srv__Trigger_Response
+ * )) before or use
+ * example_interfaces__srv__Trigger_Response__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__Trigger_Response__init(example_interfaces__srv__Trigger_Response * msg);
+
+/// Finalize srv/Trigger message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__Trigger_Response__fini(example_interfaces__srv__Trigger_Response * msg);
+
+/// Create srv/Trigger message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * example_interfaces__srv__Trigger_Response__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__Trigger_Response *
+example_interfaces__srv__Trigger_Response__create();
+
+/// Destroy srv/Trigger message.
+/**
+ * It calls
+ * example_interfaces__srv__Trigger_Response__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__Trigger_Response__destroy(example_interfaces__srv__Trigger_Response * msg);
+
+
+/// Initialize array of srv/Trigger messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * example_interfaces__srv__Trigger_Response__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+bool
+example_interfaces__srv__Trigger_Response__Sequence__init(example_interfaces__srv__Trigger_Response__Sequence * array, size_t size);
+
+/// Finalize array of srv/Trigger messages.
+/**
+ * It calls
+ * example_interfaces__srv__Trigger_Response__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__Trigger_Response__Sequence__fini(example_interfaces__srv__Trigger_Response__Sequence * array);
+
+/// Create array of srv/Trigger messages.
+/**
+ * It allocates the memory for the array and calls
+ * example_interfaces__srv__Trigger_Response__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+example_interfaces__srv__Trigger_Response__Sequence *
+example_interfaces__srv__Trigger_Response__Sequence__create(size_t size);
+
+/// Destroy array of srv/Trigger messages.
+/**
+ * It calls
+ * example_interfaces__srv__Trigger_Response__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+void
+example_interfaces__srv__Trigger_Response__Sequence__destroy(example_interfaces__srv__Trigger_Response__Sequence * array);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__DETAIL__TRIGGER__FUNCTIONS_H_

--- a/src/example_interfaces/srv/detail/trigger__rosidl_typesupport_microxrcedds_c.h
+++ b/src/example_interfaces/srv/detail/trigger__rosidl_typesupport_microxrcedds_c.h
@@ -1,0 +1,95 @@
+// generated from rosidl_typesupport_microxrcedds_c/resource/idl__rosidl_typesupport_c.h.em
+// with input from example_interfaces:srv/Trigger.idl
+// generated code does not contain a copyright notice
+#ifndef EXAMPLE_INTERFACES__SRV__TRIGGER__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+#define EXAMPLE_INTERFACES__SRV__TRIGGER__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_
+
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__srv__Trigger_Request(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__srv__Trigger_Request(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, srv, Trigger_Request)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+// already included above
+// #include <stddef.h>
+// already included above
+// #include <stdbool.h>
+// already included above
+// #include <stdint.h>
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t get_serialized_size_example_interfaces__srv__Trigger_Response(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+size_t max_serialized_size_example_interfaces__srv__Trigger_Response(
+  bool * full_bounded,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, srv, Trigger_Response)();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#include "rosidl_runtime_c/service_type_support_struct.h"
+// already included above
+// #include "rosidl_typesupport_interface/macros.h"
+// already included above
+// #include "example_interfaces/msg/rosidl_typesupport_microxrcedds_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_microxrcedds_c, example_interfaces, srv, Trigger)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__TRIGGER__ROSIDL_TYPESUPPORT_MICROXRCEDDS_C_H_

--- a/src/example_interfaces/srv/detail/trigger__struct.h
+++ b/src/example_interfaces/srv/detail/trigger__struct.h
@@ -1,0 +1,64 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from example_interfaces:srv/Trigger.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__DETAIL__TRIGGER__STRUCT_H_
+#define EXAMPLE_INTERFACES__SRV__DETAIL__TRIGGER__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Struct defined in srv/Trigger in the package example_interfaces.
+typedef struct example_interfaces__srv__Trigger_Request
+{
+  uint8_t structure_needs_at_least_one_member;
+} example_interfaces__srv__Trigger_Request;
+
+// Struct for a sequence of example_interfaces__srv__Trigger_Request.
+typedef struct example_interfaces__srv__Trigger_Request__Sequence
+{
+  example_interfaces__srv__Trigger_Request * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__srv__Trigger_Request__Sequence;
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'message'
+#include "rosidl_runtime_c/string.h"
+
+// Struct defined in srv/Trigger in the package example_interfaces.
+typedef struct example_interfaces__srv__Trigger_Response
+{
+  bool success;
+  rosidl_runtime_c__String message;
+} example_interfaces__srv__Trigger_Response;
+
+// Struct for a sequence of example_interfaces__srv__Trigger_Response.
+typedef struct example_interfaces__srv__Trigger_Response__Sequence
+{
+  example_interfaces__srv__Trigger_Response * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} example_interfaces__srv__Trigger_Response__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__DETAIL__TRIGGER__STRUCT_H_

--- a/src/example_interfaces/srv/detail/trigger__type_support.h
+++ b/src/example_interfaces/srv/detail/trigger__type_support.h
@@ -1,0 +1,58 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from example_interfaces:srv/Trigger.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__DETAIL__TRIGGER__TYPE_SUPPORT_H_
+#define EXAMPLE_INTERFACES__SRV__DETAIL__TRIGGER__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "example_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  srv,
+  Trigger_Request
+)();
+
+// already included above
+// #include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  srv,
+  Trigger_Response
+)();
+
+#include "rosidl_runtime_c/service_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_example_interfaces
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  example_interfaces,
+  srv,
+  Trigger
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EXAMPLE_INTERFACES__SRV__DETAIL__TRIGGER__TYPE_SUPPORT_H_

--- a/src/example_interfaces/srv/set_bool.h
+++ b/src/example_interfaces/srv/set_bool.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:srv/SetBool.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__SET_BOOL_H_
+#define EXAMPLE_INTERFACES__SRV__SET_BOOL_H_
+
+#include "example_interfaces/srv/detail/set_bool__struct.h"
+#include "example_interfaces/srv/detail/set_bool__functions.h"
+#include "example_interfaces/srv/detail/set_bool__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__SRV__SET_BOOL_H_

--- a/src/example_interfaces/srv/trigger.h
+++ b/src/example_interfaces/srv/trigger.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from example_interfaces:srv/Trigger.idl
+// generated code does not contain a copyright notice
+
+#ifndef EXAMPLE_INTERFACES__SRV__TRIGGER_H_
+#define EXAMPLE_INTERFACES__SRV__TRIGGER_H_
+
+#include "example_interfaces/srv/detail/trigger__struct.h"
+#include "example_interfaces/srv/detail/trigger__functions.h"
+#include "example_interfaces/srv/detail/trigger__type_support.h"
+
+#endif  // EXAMPLE_INTERFACES__SRV__TRIGGER_H_


### PR DESCRIPTION
The example **micro-ros_addtwoints_service.ino** raises the  error.


```
compilation terminated.
Using library micro_ros_arduino-galactic at version 0.0.4 in folder: C:\Users\hw630\Documents\Arduino\libraries\micro_ros_arduino-galactic 
exit status 1
example_interfaces/srv/add_two_ints.h: No such file or directory
```

These header files are available in the foxy branch, but somehow unavailable in the galactic branch.

This PR copies those missing headers from the foxy branch to the galactic branch.

Signed-off-by: wuhanstudio <wuhanstudio@qq.com>