### PR TITLE
fixed undefined reference to _write on Teensy 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Supported boards are:
 | [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)                              | v1.8.5      | Supported  | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon.meta`            |
 | [Teensy 3.2/3.1](https://www.pjrc.com/store/teensy32.html)                          | v1.8.5      | Supported  | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon_lowmem.meta`     |
 | [Teensy 3.5](https://www.pjrc.com/store/teensy35.html)                              | v1.8.5      | Not tested | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon_lowmem.meta`     |
+| [Teensy 3.6](https://www.pjrc.com/store/teensy36.html)                              | v1.8.5      | Supported  | [Based on Teensyduino](https://www.pjrc.com/teensy/td_download.html)                                | `colcon_lowmem.meta`     |
 
 Community contributed boards are:
 

--- a/src/default_transport.cpp
+++ b/src/default_transport.cpp
@@ -64,7 +64,7 @@ extern "C"
 // ---- Build fixes -----
 
 // TODO: This should be fixed
-#if defined(ARDUINO_TEENSY32) || defined(ARDUINO_TEENSY35)
+#if defined(ARDUINO_TEENSY32) || defined(ARDUINO_TEENSY35) || defined(ARDUINO_TEENSY36)
 
 extern "C" void _write(){
 }


### PR DESCRIPTION
This PR fixes undefined reference to _write when using Teensy 3.6.:

`Building in release mode
Compiling .pio/build/teensy36/src/firmware.ino.cpp.o
Compiling .pio/build/teensy36/lib9e7/micro_ros_arduino/wifi_transport.cpp.o
Linking .pio/build/teensy36/firmware.elf
/home/ubuntu/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/lib/armv7e-m/fpu/libc.a(lib_a-writer.o): In function `_write_r':
writer.c:(.text._write_r+0x12): undefined reference to `_write'
collect2: error: ld returned 1 exit status
*** [.pio/build/teensy36/firmware.elf] Error 1
`

I managed to build and upload a the pub-sub demo from the examples folder.
![pubusb](https://user-images.githubusercontent.com/5070395/126479789-7315b2c9-f85a-47c3-ae51-8efcfc4a08f8.gif)
