### PR TITLE
fixed undefined reference to _write on Teensy31 boards

### DIFF
--- a/src/default_transport.cpp
+++ b/src/default_transport.cpp
@@ -64,7 +64,7 @@ extern "C"
 // ---- Build fixes -----
 
 // TODO: This should be fixed
-#if defined(ARDUINO_TEENSY32) || defined(ARDUINO_TEENSY35) || defined(ARDUINO_TEENSY36)
+#if defined(ARDUINO_TEENSY31) || defined(ARDUINO_TEENSY32) || defined(ARDUINO_TEENSY35) || defined(ARDUINO_TEENSY36)
 
 extern "C" void _write(){
 }


### PR DESCRIPTION
This PR is related to this issue https://github.com/micro-ROS/micro_ros_arduino/pull/388 but to fix Teensy 3.1 boards instead.