### PR TITLE
Fix rollover nanoseconds

### DIFF
--- a/src/default_transport.cpp
+++ b/src/default_transport.cpp
@@ -18,17 +18,14 @@ extern "C"
   {
     (void)unused;
     static uint32_t rollover = 0;
-    static uint64_t last_measure = 0;
+    static uint32_t last_measure = 0;
 
-    uint64_t m = micros();
-    tp->tv_sec = m / 1000000;
-    tp->tv_nsec = (m % 1000000) * 1000;
-
-    // Rollover handling
+    uint32_t m = micros();
     rollover += (m < last_measure) ? 1 : 0;
-    uint64_t rollover_extra_us = rollover * micro_rollover_useconds;
-    tp->tv_sec += rollover_extra_us / 1000000;
-    tp->tv_nsec += (rollover_extra_us % 1000000) * 1000;
+
+    uint64_t real_us = (uint64_t) (m + rollover * micro_rollover_useconds);
+    tp->tv_sec = real_us / 1000000;
+    tp->tv_nsec = (real_us % 1000000) * 1000;
     last_measure = m;
 
     return 0;


### PR DESCRIPTION
Related PR: https://github.com/micro-ROS/micro_ros_arduino/pull/436

Once a rollover happens `tp->tv_nses` could overflow the permitted  values [[0, 999999999]](https://en.cppreference.com/w/c/chrono/timespec), leading to unexpected behavior. 