### PR TITLE
generate kakutef7 nonblock variation

### DIFF
--- a/extras/library_generation/colcon_nonblock.meta
+++ b/extras/library_generation/colcon_nonblock.meta
@@ -1,0 +1,56 @@
+{
+    "names": {
+        "tracetools": {
+            "cmake-args": [
+                "-DTRACETOOLS_DISABLED=ON",
+                "-DTRACETOOLS_STATUS_CHECKING_TOOL=OFF"
+            ]
+        },
+        "rosidl_typesupport": {
+            "cmake-args": [
+                "-DROSIDL_TYPESUPPORT_SINGLE_TYPESUPPORT=ON"
+            ]
+        },
+        "rcl": {
+            "cmake-args": [
+                "-DBUILD_TESTING=OFF",
+                "-DRCL_COMMAND_LINE_ENABLED=OFF",
+                "-DRCL_LOGGING_ENABLED=OFF"
+            ]
+        },
+        "rcutils": {
+            "cmake-args": [
+                "-DENABLE_TESTING=OFF",
+                "-DRCUTILS_NO_FILESYSTEM=ON",
+                "-DRCUTILS_NO_THREAD_SUPPORT=ON",
+                "-DRCUTILS_NO_64_ATOMIC=ON",
+                "-DRCUTILS_AVOID_DYNAMIC_ALLOCATION=ON"
+            ]
+        },
+        "microxrcedds_client": {
+            "cmake-args": [
+                "-DUCLIENT_PIC=OFF",
+                "-DUCLIENT_PROFILE_UDP=OFF",
+                "-DUCLIENT_PROFILE_TCP=OFF",
+                "-DUCLIENT_PROFILE_DISCOVERY=OFF",
+                "-DUCLIENT_PROFILE_SERIAL=OFF",
+                "-UCLIENT_PROFILE_STREAM_FRAMING=ON",
+                "-DUCLIENT_PROFILE_CUSTOM_TRANSPORT=ON",
+                "-DUCLIENT_MAX_SESSION_CONNECTION_ATTEMPTS=1",
+                "-DUCLIENT_MIN_SESSION_CONNECTION_INTERVAL=0"
+            ]
+        },
+        "rmw_microxrcedds": {
+            "cmake-args": [
+                "-DRMW_UXRCE_MAX_NODES=1",
+                "-DRMW_UXRCE_MAX_PUBLISHERS=10",
+                "-DRMW_UXRCE_MAX_SUBSCRIPTIONS=6",
+                "-DRMW_UXRCE_MAX_SERVICES=1",
+                "-DRMW_UXRCE_MAX_CLIENTS=1",
+                "-DRMW_UXRCE_MAX_HISTORY=4",
+                "-DRMW_UXRCE_TRANSPORT=custom",
+                "-DRMW_UXRCE_ENTITY_CREATION_DESTROY_TIMEOUT=0"
+            ]
+        }
+    }
+}

--- a/extras/library_generation/library_generation.sh
+++ b/extras/library_generation/library_generation.sh
@@ -19,6 +19,7 @@ if [ $OPTIND -eq 1 ]; then
     # PLATFORMS+=("portenta-m4")
     PLATFORMS+=("portenta-m7")
     PLATFORMS+=("kakutef7-m7")
+    PLATFORMS+=("kakutef7-m7-nonblock")
 fi
 
 shift $((OPTIND-1))
@@ -172,11 +173,15 @@ if [[ " ${PLATFORMS[@]} " =~ " portenta-m7 " ]]; then
 fi
 
 ######## Build for Kakute F7 M7 core  ########
-if [[ " ${PLATFORMS[@]} " =~ " kakutef7-m7 " ]]; then
+if [[ " ${PLATFORMS[@]} " =~ kakutef7-m7.* ]]; then
     rm -rf firmware/build
 
     export TOOLCHAIN_PREFIX=/uros_ws/gcc-arm-none-eabi-9-2020-q2-update/bin/arm-none-eabi-
-    ros2 run micro_ros_setup build_firmware.sh /project/extras/library_generation/kakutef7-m7_toolchain.cmake /project/extras/library_generation/colcon.meta
+    if [[ " ${PLATFORMS[@]} " =~ " kakutef7-m7-nonblock " ]]; then
+        ros2 run micro_ros_setup build_firmware.sh /project/extras/library_generation/kakutef7-m7_toolchain.cmake /project/extras/library_generation/colcon.meta
+    elif [[ " ${PLATFORMS[@]} " =~ " kakutef7-m7 " ]]; then
+        ros2 run micro_ros_setup build_firmware.sh /project/extras/library_generation/kakutef7-m7_toolchain.cmake /project/extras/library_generation/colcon_nonblock.meta
+    fi
 
     find firmware/build/include/ -name "*.c"  -delete
     cp -R firmware/build/include/* /project/src/


### PR DESCRIPTION
Hi,

I have a need to generate a nonblocking version this library, so i can call it from external scheduler of the OS i am using([inav](https://github.com/iNavFlight/inav)).
Nonblocking for me means to not wait for message receive inside Micro-XRCE-DDS-Client, i am achieving this by setting the variables:

```
                "-DUCLIENT_MAX_SESSION_CONNECTION_ATTEMPTS=1",
                "-DUCLIENT_MIN_SESSION_CONNECTION_INTERVAL=0"
...
                "-DRMW_UXRCE_ENTITY_CREATION_DESTROY_TIMEOUT=0"
```

Right now i am adding a new `.meta` and new platform type to generate another library, is there a better of way of doing it? And is it something you are willing to merge?