### PR TITLE
Add galactic workaround

### DIFF
--- a/extras/library_generation/library_generation.sh
+++ b/extras/library_generation/library_generation.sh
@@ -68,6 +68,11 @@ fi
 
 cd /uros_ws
 
+# Workaround for https://github.com/ros2/rosidl/pull/599
+touch firmware/mcu_ws/ros2/common_interfaces/actionlib_msgs/COLCON_IGNORE;
+touch firmware/mcu_ws/ros2/common_interfaces/std_srvs/COLCON_IGNORE;
+touch firmware/mcu_ws/ros2/example_interfaces/COLCON_IGNORE;
+
 ######## Clean and source ########
 find /project/src/ ! -name micro_ros_arduino.h ! -name *.c ! -name *.cpp ! -name *.c.in -delete
 


### PR DESCRIPTION
Workaround was merged for rolling (https://github.com/ros2/rosidl/pull/596) but not for galactic (https://github.com/ros2/rosidl/pull/599).