### PR TITLE
Fix teensy compile and board discovery for arduino-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,32 +27,21 @@ jobs:
             echo '''board_manager:
               additional_urls:
                 - https://raw.githubusercontent.com/ROBOTIS-GIT/OpenCR/master/arduino/opencr_release/package_opencr_index.json
-                - https://github.com/espressif/arduino-esp32/releases/download/2.0.2/package_esp32_index.json''' > arduino-cli.yaml
+                - https://github.com/espressif/arduino-esp32/releases/download/2.0.2/package_esp32_index.json
+                - https://www.pjrc.com/teensy/td_156/package_teensy_index.json''' > arduino-cli.yaml
             curl -fsSL https://raw.githubusercontent.com/ROBOTIS-GIT/OpenCR/master/arduino/opencr_release/package_opencr_index.json -o /github/home/.arduino15/package_opencr_index.json
             curl -fsSL https://github.com/espressif/arduino-esp32/releases/download/2.0.2/package_esp32_index.json -o /github/home/.arduino15/package_esp32_index.json
+            curl -fsSL https://www.pjrc.com/teensy/td_156/package_teensy_index.json -o /github/home/.arduino15/package_teensy_index.json
             export PATH=$PATH:/github/workspace/bin:/__w/micro_ros_arduino/micro_ros_arduino/bin
             arduino-cli core install OpenCR:OpenCR -v
             arduino-cli core install arduino:samd -v
             arduino-cli core install arduino:sam -v
             arduino-cli core install arduino:mbed -v
             arduino-cli core install esp32:esp32 -v
-            #
-            # INSTALLING TEENSY SUPPORT
-            wget https://downloads.arduino.cc/arduino-1.8.19-linux64.tar.xz
-            tar -xf arduino-1.8.19-linux64.tar.xz
-            wget https://www.pjrc.com/teensy/td_156/TeensyduinoInstall.linux64
-            chmod 755 TeensyduinoInstall.linux64
-            ./TeensyduinoInstall.linux64 --dir=arduino-1.8.19
-            # Faking Teensy loader
-            TRUE_PATH=$(which true)
-            rm -rf arduino-1.8.19/hardware/tools/teensy_post_compile
-            cp $TRUE_PATH arduino-1.8.19/hardware/tools/teensy_post_compile
-            cp -R arduino-1.8.19/hardware/teensy/ /github/home/.arduino15/packages/
-            rsync -a  arduino-1.8.19/hardware/tools/ /github/home/.arduino15/packages/tools/
-            rm -rf arduino-1.8.19 arduino-1.8.19-linux64.tar.xz
+            arduino-cli core install teensy:avr -v
             #
             # PATCHING TEENSY AND SAM
-            cat checkout/extras/patching_boards/platform_teensy.txt > /github/home/.arduino15/packages/teensy/avr/platform.txt
+            cat checkout/extras/patching_boards/platform_teensy.txt > /github/home/.arduino15/packages/teensy/hardware/avr/1.57.2/platform.txt
             # remove when https://github.com/arduino/ArduinoCore-sam/pull/115 merged
             cat checkout/extras/patching_boards/platform_arduinocore_sam.txt > /github/home/.arduino15/packages/arduino/hardware/sam/1.6.12/platform.txt
             #

--- a/extras/patching_boards/platform_teensy.txt
+++ b/extras/patching_boards/platform_teensy.txt
@@ -3,7 +3,8 @@ name=Teensyduino
 version=1.8.5
 rewriting=disabled
 
-compiler.path={runtime.hardware.path}/../tools/
+compiler.path={runtime.tools.teensy-compile.path}/
+compiler.tools_path={runtime.tools.teensy-tools.path}/
 compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
 compiler.elf2hex.flags=-O ihex -R .eeprom
 compiler.libraries.ldflags=
@@ -20,7 +21,7 @@ tools.arduino-preprocessor.cmd.path={path}/arduino-preprocessor
 tools.arduino-preprocessor.pattern="{cmd.path}" "{source_file}" "{codecomplete}" -- -std=gnu++14
 
 ## Precompile Arduino.h header
-recipe.hooks.sketch.prebuild.1.pattern="{compiler.path}precompile_helper" "{runtime.platform.path}/cores/{build.core}" "{build.path}" "{compiler.path}{build.toolchain}{build.command.g++}" -x c++-header {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{runtime.platform.path}/cores/{build.core}" "{build.path}/pch/Arduino.h" -o "{build.path}/pch/Arduino.h.gch"
+recipe.hooks.sketch.prebuild.1.pattern="{compiler.tools_path}precompile_helper" "{runtime.platform.path}/cores/{build.core}" "{build.path}" "{compiler.path}{build.toolchain}{build.command.g++}" -x c++-header {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{runtime.platform.path}/cores/{build.core}" "{build.path}/pch/Arduino.h" -o "{build.path}/pch/Arduino.h.gch"
 
 ## Compile c++ files
 recipe.cpp.o.pattern="{compiler.path}{build.toolchain}{build.command.g++}" -c {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{build.path}/pch" {includes} "{source_file}" -o "{object_file}"
@@ -47,9 +48,9 @@ recipe.objcopy.eep.pattern="{compiler.path}{build.toolchain}{build.command.objco
 recipe.objcopy.hex.pattern="{compiler.path}{build.toolchain}{build.command.objcopy}" {compiler.elf2hex.flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
 
 ## Post Build - inform Teensy Loader of new file
-recipe.hooks.postbuild.1.pattern="{compiler.path}stdout_redirect" "{build.path}/{build.project_name}.lst" "{compiler.path}{build.toolchain}{build.command.objdump}" -d -S -C "{build.path}/{build.project_name}.elf"
-recipe.hooks.postbuild.2.pattern="{compiler.path}stdout_redirect" "{build.path}/{build.project_name}.sym" "{compiler.path}{build.toolchain}{build.command.objdump}" -t -C "{build.path}/{build.project_name}.elf"
-recipe.hooks.postbuild.3.pattern="{compiler.path}teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={compiler.path}" "-board={build.board}"
+recipe.hooks.postbuild.1.pattern="{compiler.tools_path}stdout_redirect" "{build.path}/{build.project_name}.lst" "{compiler.path}{build.toolchain}{build.command.objdump}" -d -S -C "{build.path}/{build.project_name}.elf"
+recipe.hooks.postbuild.2.pattern="{compiler.tools_path}stdout_redirect" "{build.path}/{build.project_name}.sym" "{compiler.path}{build.toolchain}{build.command.objdump}" -t -C "{build.path}/{build.project_name}.elf"
+recipe.hooks.postbuild.3.pattern="{compiler.tools_path}teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={compiler.path}" "-board={build.board}"
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{build.toolchain}{build.command.size}" -A "{build.path}/{build.project_name}.elf"
@@ -57,17 +58,16 @@ recipe.size.regex=^(?:\.text|\.text\.progmem|\.text\.itcm|\.data)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.usbdescriptortable|\.dmabuffers|\.usbbuffers|\.data|\.bss|\.noinit|\.text\.itcm|\.text\.itcm\.padding)\s+([0-9]+).*
 recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 
-## Teensy Ports Discovery (Arduino 1.8.9 with pathPrefs patch)
-discovery.teensy.pattern="{runtime.hardware.path}/../tools/teensy_ports" -J2
-
-## Teensy Ports Discovery (Arduino 1.8.9)
-#discovery.teensy.pattern="{runtime.ide.path}/hardware/tools/teensy_ports" -J2
+# Arduino Boards Manager
+discovery.teensy.pattern="{runtime.tools.teensy-tools.path}/teensy_ports" -J2
+pluggable_discovery.required=teensy:teensy-discovery
+pluggable_monitor.required.teensy=teensy:teensy-monitor
 
 ## Teensy Loader
-tools.teensyloader.cmd.path={runtime.hardware.path}/../tools
+tools.teensyloader.cmd.path={runtime.tools.teensy-tools.path}
 tools.teensyloader.upload.params.quiet=
 tools.teensyloader.upload.params.verbose=-verbose
-tools.teensyloader.upload.pattern="{cmd.path}/teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={cmd.path}" "-board={build.board}" -reboot "-port={serial.port}" "-portlabel={serial.port.label}" "-portprotocol={serial.port.protocol}"
+tools.teensyloader.upload.pattern="{runtime.tools.teensy-tools.path}/teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={cmd.path}" "-board={build.board}" -reboot "-port={serial.port}" "-portlabel={serial.port.label}" "-portprotocol={serial.port.protocol}"
 
 ## Export hex
 recipe.output.tmp_file={build.project_name}.hex

--- a/extras/patching_boards/platform_teensy.txt
+++ b/extras/patching_boards/platform_teensy.txt
@@ -1,10 +1,18 @@
-# http://www.pjrc.com/teensy/teensyduino.html
 name=Teensyduino
 version=1.8.5
 rewriting=disabled
 
+# Teensyduino Installer
+#compiler.path={runtime.hardware.path}/../tools/
+#teensytools.path={runtime.hardware.path}/../tools/
+
+# Arduino Boards Manager
 compiler.path={runtime.tools.teensy-compile.path}/
-compiler.tools_path={runtime.tools.teensy-tools.path}/
+teensytools.path={runtime.tools.teensy-tools.path}/
+
+
+
+## EEPROM Data
 compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
 compiler.elf2hex.flags=-O ihex -R .eeprom
 compiler.libraries.ldflags=
@@ -21,7 +29,7 @@ tools.arduino-preprocessor.cmd.path={path}/arduino-preprocessor
 tools.arduino-preprocessor.pattern="{cmd.path}" "{source_file}" "{codecomplete}" -- -std=gnu++14
 
 ## Precompile Arduino.h header
-recipe.hooks.sketch.prebuild.1.pattern="{compiler.tools_path}precompile_helper" "{runtime.platform.path}/cores/{build.core}" "{build.path}" "{compiler.path}{build.toolchain}{build.command.g++}" -x c++-header {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{runtime.platform.path}/cores/{build.core}" "{build.path}/pch/Arduino.h" -o "{build.path}/pch/Arduino.h.gch"
+recipe.hooks.sketch.prebuild.1.pattern="{teensytools.path}precompile_helper" "{runtime.platform.path}/cores/{build.core}" "{build.path}" "{compiler.path}{build.toolchain}{build.command.g++}" -x c++-header {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{runtime.platform.path}/cores/{build.core}" "{build.path}/pch/Arduino.h" -o "{build.path}/pch/Arduino.h.gch"
 
 ## Compile c++ files
 recipe.cpp.o.pattern="{compiler.path}{build.toolchain}{build.command.g++}" -c {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{build.path}/pch" {includes} "{source_file}" -o "{object_file}"
@@ -38,8 +46,8 @@ recipe.ar.pattern="{compiler.path}{build.toolchain}{build.command.ar}" rcs "{arc
 ## Link
 recipe.c.combine.pattern="{compiler.path}{build.toolchain}{build.command.linker}" {build.flags.optimize} {build.flags.ld} {build.flags.ldspecs} {build.flags.cpu} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" {compiler.libraries.ldflags} "-L{build.path}" {build.flags.libs}
 
-## Patch ELF - TODO: not supported by Arduino 1.6.6 builder
-recipe.elfpatch.pattern="{compiler.path}/hardware/tools/{build.elfpatch}" -mmcu={build.mcu} "{build.path}/{build.project_name}.elf" "{sketch_path}/disk"
+## Patch ELF - TODO: not supported by modern Arduino...  :(
+recipe.elfpatch.pattern="{teensytools.path}/{build.elfpatch}" -mmcu={build.mcu} "{build.path}/{build.project_name}.elf" "{sketch_path}/disk"
 
 ## Create eeprom
 recipe.objcopy.eep.pattern="{compiler.path}{build.toolchain}{build.command.objcopy}" {compiler.objcopy.eep.flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"
@@ -47,31 +55,60 @@ recipe.objcopy.eep.pattern="{compiler.path}{build.toolchain}{build.command.objco
 ## Create hex
 recipe.objcopy.hex.pattern="{compiler.path}{build.toolchain}{build.command.objcopy}" {compiler.elf2hex.flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
 
+## EHEX file - for Teensy 4.x secure mode
+recipe.hooks.objcopy.postobjcopy.1.pattern="{teensytools.path}teensy_secure" encrypthex {build.board} "{build.path}/{build.project_name}.hex"
+
+
 ## Post Build - inform Teensy Loader of new file
-recipe.hooks.postbuild.1.pattern="{compiler.tools_path}stdout_redirect" "{build.path}/{build.project_name}.lst" "{compiler.path}{build.toolchain}{build.command.objdump}" -d -S -C "{build.path}/{build.project_name}.elf"
-recipe.hooks.postbuild.2.pattern="{compiler.tools_path}stdout_redirect" "{build.path}/{build.project_name}.sym" "{compiler.path}{build.toolchain}{build.command.objdump}" -t -C "{build.path}/{build.project_name}.elf"
-recipe.hooks.postbuild.3.pattern="{compiler.tools_path}teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={compiler.path}" "-board={build.board}"
+recipe.hooks.postbuild.1.pattern="{teensytools.path}teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={teensytools.path}" "-board={build.board}"
+recipe.hooks.postbuild.2.pattern="{teensytools.path}stdout_redirect" "{build.path}/{build.project_name}.sym" "{compiler.path}{build.toolchain}{build.command.objdump}" -t -C "{build.path}/{build.project_name}.elf"
+recipe.hooks.postbuild.3.pattern="{teensytools.path}teensy_size" "{build.path}/{build.project_name}.elf"
+#
+# objdump to create .lst file is VERY SLOW for huge files
+# https://forum.pjrc.com/threads/68121?p=288306&viewfull=1#post288306
+#
+# recipe.hooks.postbuild.4.pattern="{teensytools.path}stdout_redirect" "{build.path}/{build.project_name}.lst" "{compiler.path}{build.toolchain}{build.command.objdump}" -d -S -C "{build.path}/{build.project_name}.elf"
+
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{build.toolchain}{build.command.size}" -A "{build.path}/{build.project_name}.elf"
-recipe.size.regex=^(?:\.text|\.text\.progmem|\.text\.itcm|\.data)\s+([0-9]+).*
+recipe.size.regex=^(?:\.text|\.text\.progmem|\.text\.itcm|\.data|\.text\.csf)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.usbdescriptortable|\.dmabuffers|\.usbbuffers|\.data|\.bss|\.noinit|\.text\.itcm|\.text\.itcm\.padding)\s+([0-9]+).*
 recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
+
+## Teensy Ports Discovery
+##  Arduino 1.8.9 requires pathPrefs patch
+##  discovery patters have only limited support for substitution macros,
+##  so we can not use {teensytools.path} or {compiler.path} here
+
+# Teensyduino Installer
+#discovery.teensy.pattern="{runtime.hardware.path}/../tools/teensy_ports" -J2
 
 # Arduino Boards Manager
 discovery.teensy.pattern="{runtime.tools.teensy-tools.path}/teensy_ports" -J2
 pluggable_discovery.required=teensy:teensy-discovery
 pluggable_monitor.required.teensy=teensy:teensy-monitor
 
+
 ## Teensy Loader
+
+# Teensyduino Installer
+#tools.teensyloader.cmd.path={runtime.hardware.path}/../tools
+
+# Arduino Boards Manager
 tools.teensyloader.cmd.path={runtime.tools.teensy-tools.path}
+
 tools.teensyloader.upload.params.quiet=
 tools.teensyloader.upload.params.verbose=-verbose
-tools.teensyloader.upload.pattern="{runtime.tools.teensy-tools.path}/teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={cmd.path}" "-board={build.board}" -reboot "-port={serial.port}" "-portlabel={serial.port.label}" "-portprotocol={serial.port.protocol}"
+tools.teensyloader.upload.pattern="{cmd.path}/teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={cmd.path}" "-board={build.board}" -reboot "-port={serial.port}" "-portlabel={serial.port.label}" "-portprotocol={serial.port.protocol}"
+
+
+
 
 ## Export hex
 recipe.output.tmp_file={build.project_name}.hex
 recipe.output.save_file={build.project_name}.{build.board}.hex
+recipe.hooks.savehex.postsavehex.1.pattern="{teensytools.path}teensy_secure" encrypthex {build.board} "{sketch_path}/{build.project_name}.{build.board}.hex"
 
 # TODO: missing patch in 1.6.6...
 recipe.output.tmp_file2={build.project_name}.elf
@@ -79,4 +116,4 @@ recipe.output.save_file2={build.project_name}.elf
 
 
 # documentation on this file's format
-# https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
+# https://arduino.github.io/arduino-cli/latest/platform-specification/


### PR DESCRIPTION
Closes #1181 #1192 

Fixes out-of-date paths for locations of compiler toolchain and additional teensy tools for arduino-cli. In addition, pulls upstream changes for board discovery from the default platform.txt. I am unsure of the impact this has on IDE users but I would assume the paths are updated for 2.0.0 as well.