### PR TITLE
Wio Terminal Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,18 @@ jobs:
             echo '''board_manager:
               additional_urls:
                 - https://raw.githubusercontent.com/ROBOTIS-GIT/OpenCR/master/arduino/opencr_release/package_opencr_index.json
-                - https://github.com/espressif/arduino-esp32/releases/download/2.0.2/package_esp32_index.json''' > arduino-cli.yaml
+                - https://github.com/espressif/arduino-esp32/releases/download/2.0.2/package_esp32_index.json
+                - https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json''' > arduino-cli.yaml
             curl -fsSL https://raw.githubusercontent.com/ROBOTIS-GIT/OpenCR/master/arduino/opencr_release/package_opencr_index.json -o /github/home/.arduino15/package_opencr_index.json
             curl -fsSL https://github.com/espressif/arduino-esp32/releases/download/2.0.2/package_esp32_index.json -o /github/home/.arduino15/package_esp32_index.json
+            curl -fsSL https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json -o /github/home/.arduino15/package_seeeduino_boards_index.json
             export PATH=$PATH:/github/workspace/bin:/__w/micro_ros_arduino/micro_ros_arduino/bin
             arduino-cli core install OpenCR:OpenCR -v
             arduino-cli core install arduino:samd -v
             arduino-cli core install arduino:sam -v
             arduino-cli core install arduino:mbed -v
             arduino-cli core install esp32:esp32 -v
+            arduino-cli core install Seeeduino:samd -v
             #
             # INSTALLING TEENSY SUPPORT
             wget https://downloads.arduino.cc/arduino-1.8.19-linux64.tar.xz
@@ -60,6 +63,7 @@ jobs:
             arduino-cli core update-index
             arduino-cli lib update-index
             arduino-cli lib install WiFiNINA
+            arduino-cli lib install "Seeed Arduino rpcWiFi" # Dependent libraries(e.g. "Seeed Arduino rpcUnified") will be installed together. See https://wiki.seeedstudio.com/Wio-Terminal-Network-Overview/#needed-libraries-for-wi-fi for more details.
             # Build all demos
             arduino-cli compile --fqbn OpenCR:OpenCR:OpenCR /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher -v
             arduino-cli compile --fqbn OpenCR:OpenCR:OpenCR /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_addtwoints_service -v
@@ -83,3 +87,4 @@ jobs:
             arduino-cli compile --fqbn arduino:mbed:envie_m7 /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v
             arduino-cli compile --fqbn esp32:esp32:esp32 /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher -v
             arduino-cli compile --fqbn esp32:esp32:esp32 /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v
+            arduino-cli compile --fqbn Seeeduino:samd:seeed_wio_terminal /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Community contributed boards are:
 | [Arduino Zero](https://store.arduino.cc/arduino-zero)                                    | -           | [@lukicdarkoo](https://github.com/lukicdarkoo) |         | `colcon_verylowmem.meta` |
 | [Kakute F7](http://www.holybro.com/product/kakute-f7-aio-v1-5/)                          | -           | [@amfern](https://github.com/amfern)           |         | `colcon.meta`            |
 | [STM32-E407](https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf) | -           | [@dominikn](https://github.com/dominikn)       |         | `colcon.meta`            |
+| [Wio Terminal](https://wiki.seeedstudio.com/Wio-Terminal-Getting-Started/) | -           | [@maehara-keisuke](https://github.com/maehara-keisuke)       |         | `colcon.meta`            |
 
 You can find the available precompiled ROS 2 types for messages and services in [available_ros2_types](available_ros2_types).
 

--- a/examples/micro-ros_publisher_wifi/micro-ros_publisher_wifi.ino
+++ b/examples/micro-ros_publisher_wifi/micro-ros_publisher_wifi.ino
@@ -8,8 +8,8 @@
 
 #include <std_msgs/msg/int32.h>
 
-#if !defined(ESP32) && !defined(TARGET_PORTENTA_H7_M7) && !defined(ARDUINO_NANO_RP2040_CONNECT)
-#error This example is only avaible for Arduino Portenta, Arduino Nano RP2040 Connect and ESP32 Dev module
+#if !defined(ESP32) && !defined(TARGET_PORTENTA_H7_M7) && !defined(ARDUINO_NANO_RP2040_CONNECT) && !defined(ARDUINO_WIO_TERMINAL)
+#error This example is only avaible for Arduino Portenta, Arduino Nano RP2040 Connect, ESP32 Dev module and Wio Terminal
 #endif
 
 rcl_publisher_t publisher;

--- a/src/micro_ros_arduino.h
+++ b/src/micro_ros_arduino.h
@@ -95,7 +95,7 @@ static inline void set_microros_native_ethernet_udp_transports(byte mac[], IPAdd
 
 #endif
 
-#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT)
+#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_WIO_TERMINAL)
 
 #if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7)
 #include <WiFi.h>
@@ -103,6 +103,9 @@ static inline void set_microros_native_ethernet_udp_transports(byte mac[], IPAdd
 #elif defined(ARDUINO_NANO_RP2040_CONNECT)
 #include <SPI.h>
 #include <WiFiNINA.h>
+#elif defined(ARDUINO_WIO_TERMINAL)
+#include <rpcWiFi.h>
+#include <WiFiUdp.h>
 #endif
 
 extern "C" bool arduino_wifi_transport_open(struct uxrCustomTransport * transport);

--- a/src/wifi_transport.cpp
+++ b/src/wifi_transport.cpp
@@ -1,5 +1,4 @@
-#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT)
-
+#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_WIO_TERMINAL)
 #include <Arduino.h>
 
 
@@ -9,6 +8,9 @@
 #elif defined(ARDUINO_NANO_RP2040_CONNECT)
 #include <SPI.h>
 #include <WiFiNINA.h>
+#elif defined(ARDUINO_WIO_TERMINAL)
+#include <rpcWiFi.h>
+#include <WiFiUdp.h>
 #endif
 
 #include <micro_ros_arduino.h>


### PR DESCRIPTION
# What I changed

- Enable to compile `micro-ros_publisher_wifi` example when target is [Wio Terminal](https://wiki.seeedstudio.com/Wio-Terminal-Getting-Started/).
- Update CI for build example test.
- Add Wio Terminal to community contributed board list.

# What I tested

- Run CI successfully in my forked repository.
- Build example below in local environment and Run  successfully on Wio Terminal.
  - `micro-ros_addtwoints_service`
  - `micro-ros_publisher`
  - `micro-ros_publisher_wifi`
  - `micro-ros_reconnection_example`
  - `micro-ros_subscriber`
  - `micro-ros_subscriber_twist`