### PR TITLE
WiFiEspAT Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,19 +82,11 @@ jobs:
             arduino-cli compile --fqbn esp32:esp32:esp32 /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher -v
             arduino-cli compile --fqbn esp32:esp32:esp32 /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v
             arduino-cli compile --fqbn Seeeduino:samd:seeed_wio_terminal /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v
-            # BUILDING micro-ros_publisher-wifi for WiFi non-native board with ESP-AT(expected to succeed)
-            arduino-cli compile --build-property "build.extra_flags=-DUSE_WIFI_ESP_AT -DESP_AT_SERIAL_PORT=Serial1 -DESP_AT_BAUDRATE=115200 -DESP_AT_RESET_PIN=-1" --fqbn arduino:mbed:pico /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v
-            # BUILDING micro-ros_publisher-wifi for WiFi native board with ESP-AT(expected to fail)
+            # Build micro-ros_publisher-wifi_at for WiFi non-native board with ESP-AT
+            arduino-cli compile --fqbn arduino:mbed:pico /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi_at -v
+            # Build micro-ros_publisher-wifi_at for WiFi native board with ESP-AT to check whether #error macro works or not
             return_code=0
-            arduino-cli compile --build-property "build.extra_flags=-DUSE_WIFI_ESP_AT -DESP_AT_SERIAL_PORT=Serial1 -DESP_AT_BAUDRATE=115200 -DESP_AT_RESET_PIN=-1" --fqbn arduino:mbed:nanorp2040connect /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v || return_code=$?
-            if [ $return_code -eq 0 ]
-            then
-            echo Build succeeded as not expected!
-            exit 1
-            fi
-            # BUILDING micro-ros_publisher-wifi for WiFi non-native board without definition "USE_WIFI_ESP_AT'"(expected to fail)
-            return_code=0
-            arduino-cli compile --fqbn arduino:mbed:pico /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v || return_code=$?
+            arduino-cli compile --fqbn arduino:mbed:nanorp2040connect /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi_at -v || return_code=$?
             if [ $return_code -eq 0 ]
             then
             echo Build succeeded as not expected!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,3 @@ jobs:
             arduino-cli compile --fqbn Seeeduino:samd:seeed_wio_terminal /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v
             # Build micro-ros_publisher-wifi_at for WiFi non-native board with ESP-AT
             arduino-cli compile --fqbn arduino:mbed:pico /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi_at -v
-            # Build micro-ros_publisher-wifi_at for WiFi native board with ESP-AT to check whether #error macro works or not
-            return_code=0
-            arduino-cli compile --fqbn arduino:mbed:nanorp2040connect /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi_at -v || return_code=$?
-            if [ $return_code -eq 0 ]
-            then
-            echo Build succeeded as not expected!
-            exit 1
-            fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
             arduino-cli lib install WiFiNINA
             arduino-cli lib install "STM32duino X-NUCLEO-IKS01A3"
             arduino-cli lib install "Seeed Arduino rpcWiFi" # Dependent libraries(e.g. "Seeed Arduino rpcUnified") will be installed together. See https://wiki.seeedstudio.com/Wio-Terminal-Network-Overview/#needed-libraries-for-wi-fi for more details.
+            arduino-cli lib install WiFiEspAT
             # Build all demos
             arduino-cli compile --fqbn OpenCR:OpenCR:OpenCR /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher -v
             arduino-cli compile --fqbn OpenCR:OpenCR:OpenCR /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_addtwoints_service -v
@@ -81,3 +82,21 @@ jobs:
             arduino-cli compile --fqbn esp32:esp32:esp32 /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher -v
             arduino-cli compile --fqbn esp32:esp32:esp32 /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v
             arduino-cli compile --fqbn Seeeduino:samd:seeed_wio_terminal /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v
+            # BUILDING micro-ros_publisher-wifi for WiFi non-native board with ESP-AT(expected to succeed)
+            arduino-cli compile --build-property "build.extra_flags=-DUSE_WIFI_ESP_AT -DESP_AT_SERIAL_PORT=Serial1 -DESP_AT_BAUDRATE=115200 -DESP_AT_RESET_PIN=-1" --fqbn arduino:mbed:pico /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v
+            # BUILDING micro-ros_publisher-wifi for WiFi native board with ESP-AT(expected to fail)
+            return_code=0
+            arduino-cli compile --build-property "build.extra_flags=-DUSE_WIFI_ESP_AT -DESP_AT_SERIAL_PORT=Serial1 -DESP_AT_BAUDRATE=115200 -DESP_AT_RESET_PIN=-1" --fqbn arduino:mbed:nanorp2040connect /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v || return_code=$?
+            if [ $return_code -eq 0 ]
+            then
+            echo Build succeeded as not expected!
+            exit 1
+            fi
+            # BUILDING micro-ros_publisher-wifi for WiFi non-native board without definition "USE_WIFI_ESP_AT'"(expected to fail)
+            return_code=0
+            arduino-cli compile --fqbn arduino:mbed:pico /github/home/Arduino/libraries/micro_ros_arduino/examples/micro-ros_publisher_wifi -v || return_code=$?
+            if [ $return_code -eq 0 ]
+            then
+            echo Build succeeded as not expected!
+            exit 1
+            fi

--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ Community contributed boards are:
 
 You can find the available precompiled ROS 2 types for messages and services in [available_ros2_types](available_ros2_types).
 
+### Community confirmed External WiFi module
+
+At present, few boards have native WiFi interface and can use WiFi UDP Transport.
+
+Meanwhile, many WiFi non-native boards have secondary UART channel(in most cases, assigned as `Serial1`). 
+And we may use WiFi UDP Transport by connecting ESP-AT External WiFi module to this channel.
+
+See [ESP-AT Resources](https://www.espressif.com/en/products/sdks/esp-at/overview) for more details about ESP-AT External WiFi module. And try `examples/micro-ros_publisher_wifi`
+
+Community confirmed combinations of board and ESP-AT module are:
+
+| Board                                                                            | Board Definition                                                             | ESP-AT Module                                                                                                      | ESP-AT Firmware version                                                                       | Note                                                                                                                                                 | Confirmed By                                           |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| [Raspberry Pi Pico](https://www.raspberrypi.com/documentation/microcontrollers/) | [Arduino Mbed OS RP2040 Boards](https://github.com/arduino/ArduinoCore-mbed) | [ESP32C3-WROOM-02](https://www.espressif.com/sites/default/files/documentation/esp32-c3-wroom-02_datasheet_en.pdf) | [v2.4.2.0](https://dl.espressif.com/esp-at/firmwares/esp32c3/ESP32-C3-MINI-1-AT-V2.4.2.0.zip) |                                                                                                                                                      | [@maehara-keisuke](https://github.com/maehara-keisuke) |
+| [Seeed Studio XIAO SAMD21](https://wiki.seeedstudio.com/Seeeduino-XIAO/)         | [Seeed SAMD Boards](https://github.com/Seeed-Studio/ArduinoCore-samd)        | [ESP32C3-WROOM-02](https://www.espressif.com/sites/default/files/documentation/esp32-c3-wroom-02_datasheet_en.pdf) | [v2.4.2.0](https://dl.espressif.com/esp-at/firmwares/esp32c3/ESP32-C3-MINI-1-AT-V2.4.2.0.zip) |                                                                                                                                                      | [@maehara-keisuke](https://github.com/maehara-keisuke) |
+| [Seeed Studio XIAO RP2040](https://wiki.seeedstudio.com/XIAO-RP2040/)            | [Arduino Mbed OS RP2040 Boards](https://github.com/arduino/ArduinoCore-mbed) | [ESP32C3-WROOM-02](https://www.espressif.com/sites/default/files/documentation/esp32-c3-wroom-02_datasheet_en.pdf) | [v2.4.2.0](https://dl.espressif.com/esp-at/firmwares/esp32c3/ESP32-C3-MINI-1-AT-V2.4.2.0.zip) | Follow chip pinout to determine right pin function. Silk printing on board is for [other framework](https://github.com/earlephilhower/arduino-pico). | [@maehara-keisuke](https://github.com/maehara-keisuke) |
+
 ## How to use the precompiled library
 
 ### Arduino IDE

--- a/README.md
+++ b/README.md
@@ -24,27 +24,27 @@ As the build process for ROS 2 and micro-ROS is based on custom meta-build syste
 
 Supported boards are:
 
-| Board                                                                               | Min version | State      | Details                                                                                             | .meta file               |
-| ----------------------------------------------------------------------------------- | ----------- | ---------- | --------------------------------------------------------------------------------------------------- | ------------------------ |
-| [Arduino Portenta H7 M7 Core](https://store.arduino.cc/portenta-h7)                 | v1.8.5      | Supported  | Official Arduino support                                                                            | `colcon.meta`            |
-| [Arduino Nano RP2040 Connect](https://docs.arduino.cc/hardware/nano-rp2040-connect) | v1.8.5      | Supported  | Official Arduino support                                                                            | `colcon_verylowmem.meta` |
-| [OpenCR](https://emanual.robotis.com/docs/en/parts/controller/opencr10/)            | v1.4.16     | Supported  | [Based on custom board](https://emanual.robotis.com/docs/en/parts/controller/opencr10/#arduino-ide) | `colcon.meta`            |
-| [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)                              | v1.8.5      | Not tested | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                                | `colcon.meta`            |
-| [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)                              | v1.8.5      | Supported  | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                                | `colcon.meta`            |
-| [Teensy 3.2/3.1](https://www.pjrc.com/store/teensy32.html)                          | v1.8.5      | Supported  | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                                | `colcon_lowmem.meta`     |
-| [Teensy 3.5](https://www.pjrc.com/store/teensy35.html)                              | v1.8.5      | Not tested | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                                | `colcon_lowmem.meta`     |
-| [Teensy 3.6](https://www.pjrc.com/store/teensy36.html)                              | v1.8.5      | Supported  | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                                | `colcon_lowmem.meta`     |
-| [ESP32 Dev Module](https://docs.espressif.com/projects/arduino-esp32/en/latest/boards/ESP32-DevKitC-1.html) | v1.8.5  | Supported  | [Arduino core for the ESP32 (v2.0.2)](https://github.com/espressif/arduino-esp32/releases/tag/2.0.2) | `colcon.meta`   |
+| Board                                                                                                       | Min version | State      | Details                                                                                              | .meta file               |
+| ----------------------------------------------------------------------------------------------------------- | ----------- | ---------- | ---------------------------------------------------------------------------------------------------- | ------------------------ |
+| [Arduino Portenta H7 M7 Core](https://store.arduino.cc/portenta-h7)                                         | v1.8.5      | Supported  | Official Arduino support                                                                             | `colcon.meta`            |
+| [Arduino Nano RP2040 Connect](https://docs.arduino.cc/hardware/nano-rp2040-connect)                         | v1.8.5      | Supported  | Official Arduino support                                                                             | `colcon_verylowmem.meta` |
+| [OpenCR](https://emanual.robotis.com/docs/en/parts/controller/opencr10/)                                    | v1.4.16     | Supported  | [Based on custom board](https://emanual.robotis.com/docs/en/parts/controller/opencr10/#arduino-ide)  | `colcon.meta`            |
+| [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)                                                      | v1.8.5      | Not tested | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                       | `colcon.meta`            |
+| [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)                                                      | v1.8.5      | Supported  | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                       | `colcon.meta`            |
+| [Teensy 3.2/3.1](https://www.pjrc.com/store/teensy32.html)                                                  | v1.8.5      | Supported  | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                       | `colcon_lowmem.meta`     |
+| [Teensy 3.5](https://www.pjrc.com/store/teensy35.html)                                                      | v1.8.5      | Not tested | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                       | `colcon_lowmem.meta`     |
+| [Teensy 3.6](https://www.pjrc.com/store/teensy36.html)                                                      | v1.8.5      | Supported  | [Based on Teensyduino](https://www.pjrc.com/arduino-ide-2-0-0-teensy-support/)                       | `colcon_lowmem.meta`     |
+| [ESP32 Dev Module](https://docs.espressif.com/projects/arduino-esp32/en/latest/boards/ESP32-DevKitC-1.html) | v1.8.5      | Supported  | [Arduino core for the ESP32 (v2.0.2)](https://github.com/espressif/arduino-esp32/releases/tag/2.0.2) | `colcon.meta`            |
 
 Community contributed boards are:
 
-| Board                                                                                    | Min version | Contributor                                    | Details | .meta file               |
-| ---------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------- | ------- | ------------------------ |
-| [Arduino Due](https://store.arduino.cc/arduino-due)                                      | -           | [@lukicdarkoo](https://github.com/lukicdarkoo) |         | `colcon_verylowmem.meta` |
-| [Arduino Zero](https://store.arduino.cc/arduino-zero)                                    | -           | [@lukicdarkoo](https://github.com/lukicdarkoo) |         | `colcon_verylowmem.meta` |
-| [Kakute F7](http://www.holybro.com/product/kakute-f7-aio-v1-5/)                          | -           | [@amfern](https://github.com/amfern)           |         | `colcon.meta`            |
-| [STM32-E407](https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf) | -           | [@dominikn](https://github.com/dominikn)       |         | `colcon.meta`            |
-| [Wio Terminal](https://wiki.seeedstudio.com/Wio-Terminal-Getting-Started/) | -           | [@maehara-keisuke](https://github.com/maehara-keisuke)       |         | `colcon.meta`            |
+| Board                                                                                    | Min version | Contributor                                            | Details | .meta file               |
+| ---------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------ | ------- | ------------------------ |
+| [Arduino Due](https://store.arduino.cc/arduino-due)                                      | -           | [@lukicdarkoo](https://github.com/lukicdarkoo)         |         | `colcon_verylowmem.meta` |
+| [Arduino Zero](https://store.arduino.cc/arduino-zero)                                    | -           | [@lukicdarkoo](https://github.com/lukicdarkoo)         |         | `colcon_verylowmem.meta` |
+| [Kakute F7](http://www.holybro.com/product/kakute-f7-aio-v1-5/)                          | -           | [@amfern](https://github.com/amfern)                   |         | `colcon.meta`            |
+| [STM32-E407](https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf) | -           | [@dominikn](https://github.com/dominikn)               |         | `colcon.meta`            |
+| [Wio Terminal](https://wiki.seeedstudio.com/Wio-Terminal-Getting-Started/)               | -           | [@maehara-keisuke](https://github.com/maehara-keisuke) |         | `colcon.meta`            |
 
 You can find the available precompiled ROS 2 types for messages and services in [available_ros2_types](available_ros2_types).
 

--- a/README.md
+++ b/README.md
@@ -38,32 +38,18 @@ Supported boards are:
 
 Community contributed boards are:
 
-| Board                                                                                    | Min version | Contributor                                            | Details | .meta file               |
-| ---------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------ | ------- | ------------------------ |
-| [Arduino Due](https://store.arduino.cc/arduino-due)                                      | -           | [@lukicdarkoo](https://github.com/lukicdarkoo)         |         | `colcon_verylowmem.meta` |
-| [Arduino Zero](https://store.arduino.cc/arduino-zero)                                    | -           | [@lukicdarkoo](https://github.com/lukicdarkoo)         |         | `colcon_verylowmem.meta` |
-| [Kakute F7](http://www.holybro.com/product/kakute-f7-aio-v1-5/)                          | -           | [@amfern](https://github.com/amfern)                   |         | `colcon.meta`            |
-| [STM32-E407](https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf) | -           | [@dominikn](https://github.com/dominikn)               |         | `colcon.meta`            |
-| [Wio Terminal](https://wiki.seeedstudio.com/Wio-Terminal-Getting-Started/)               | -           | [@maehara-keisuke](https://github.com/maehara-keisuke) |         | `colcon.meta`            |
+| Board                                                                                    | Min version | Contributor                                            | Details                                                                   | .meta file               |
+| ---------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------ | ------------------------------------------------------------------------- | ------------------------ |
+| [Arduino Due](https://store.arduino.cc/arduino-due)                                      | -           | [@lukicdarkoo](https://github.com/lukicdarkoo)         |                                                                           | `colcon_verylowmem.meta` |
+| [Arduino Zero](https://store.arduino.cc/arduino-zero)                                    | -           | [@lukicdarkoo](https://github.com/lukicdarkoo)         |                                                                           | `colcon_verylowmem.meta` |
+| [Kakute F7](http://www.holybro.com/product/kakute-f7-aio-v1-5/)                          | -           | [@amfern](https://github.com/amfern)                   |                                                                           | `colcon.meta`            |
+| [STM32-E407](https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf) | -           | [@dominikn](https://github.com/dominikn)               |                                                                           | `colcon.meta`            |
+| [Wio Terminal](https://wiki.seeedstudio.com/Wio-Terminal-Getting-Started/)               | -           | [@maehara-keisuke](https://github.com/maehara-keisuke) |                                                                           | `colcon.meta`            |
+| [Raspberry Pi Pico](https://www.raspberrypi.com/documentation/microcontrollers/)         | -           | [@maehara-keisuke](https://github.com/maehara-keisuke) | with [ESP-AT](https://www.espressif.com/en/products/sdks/esp-at/overview) | `colcon_verylowmem.meta` |
+| [Seeed Studio XIAO SAMD21](https://wiki.seeedstudio.com/Seeeduino-XIAO/)                 | -           | [@maehara-keisuke](https://github.com/maehara-keisuke) | with [ESP-AT](https://www.espressif.com/en/products/sdks/esp-at/overview) | `colcon_verylowmem.meta` |
+| [Seeed Studio XIAO RP2040](https://wiki.seeedstudio.com/XIAO-RP2040/)                    | -           | [@maehara-keisuke](https://github.com/maehara-keisuke) | with [ESP-AT](https://www.espressif.com/en/products/sdks/esp-at/overview) | `colcon_verylowmem.meta` |
 
 You can find the available precompiled ROS 2 types for messages and services in [available_ros2_types](available_ros2_types).
-
-### Community confirmed External WiFi module
-
-At present, few boards have native WiFi interface and can use WiFi UDP Transport.
-
-Meanwhile, many WiFi non-native boards have secondary UART channel(in most cases, assigned as `Serial1`). 
-And we may use WiFi UDP Transport by connecting ESP-AT External WiFi module to this channel.
-
-See [ESP-AT Resources](https://www.espressif.com/en/products/sdks/esp-at/overview) for more details about ESP-AT External WiFi module. And try `examples/micro-ros_publisher_wifi`
-
-Community confirmed combinations of board and ESP-AT module are:
-
-| Board                                                                            | Board Definition                                                             | ESP-AT Module                                                                                                      | ESP-AT Firmware version                                                                       | Note                                                                                                                                                 | Confirmed By                                           |
-| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| [Raspberry Pi Pico](https://www.raspberrypi.com/documentation/microcontrollers/) | [Arduino Mbed OS RP2040 Boards](https://github.com/arduino/ArduinoCore-mbed) | [ESP32C3-WROOM-02](https://www.espressif.com/sites/default/files/documentation/esp32-c3-wroom-02_datasheet_en.pdf) | [v2.4.2.0](https://dl.espressif.com/esp-at/firmwares/esp32c3/ESP32-C3-MINI-1-AT-V2.4.2.0.zip) |                                                                                                                                                      | [@maehara-keisuke](https://github.com/maehara-keisuke) |
-| [Seeed Studio XIAO SAMD21](https://wiki.seeedstudio.com/Seeeduino-XIAO/)         | [Seeed SAMD Boards](https://github.com/Seeed-Studio/ArduinoCore-samd)        | [ESP32C3-WROOM-02](https://www.espressif.com/sites/default/files/documentation/esp32-c3-wroom-02_datasheet_en.pdf) | [v2.4.2.0](https://dl.espressif.com/esp-at/firmwares/esp32c3/ESP32-C3-MINI-1-AT-V2.4.2.0.zip) |                                                                                                                                                      | [@maehara-keisuke](https://github.com/maehara-keisuke) |
-| [Seeed Studio XIAO RP2040](https://wiki.seeedstudio.com/XIAO-RP2040/)            | [Arduino Mbed OS RP2040 Boards](https://github.com/arduino/ArduinoCore-mbed) | [ESP32C3-WROOM-02](https://www.espressif.com/sites/default/files/documentation/esp32-c3-wroom-02_datasheet_en.pdf) | [v2.4.2.0](https://dl.espressif.com/esp-at/firmwares/esp32c3/ESP32-C3-MINI-1-AT-V2.4.2.0.zip) | Follow chip pinout to determine right pin function. Silk printing on board is for [other framework](https://github.com/earlephilhower/arduino-pico). | [@maehara-keisuke](https://github.com/maehara-keisuke) |
 
 ## How to use the precompiled library
 

--- a/examples/micro-ros_publisher_wifi/micro-ros_publisher_wifi.ino
+++ b/examples/micro-ros_publisher_wifi/micro-ros_publisher_wifi.ino
@@ -9,7 +9,7 @@
 #include <std_msgs/msg/int32.h>
 
 #if !defined(ESP32) && !defined(TARGET_PORTENTA_H7_M7) && !defined(ARDUINO_NANO_RP2040_CONNECT) && !defined(ARDUINO_WIO_TERMINAL)
-#error This example is only avaible for Arduino Portenta, Arduino Nano RP2040 Connect, ESP32 Dev module and Wio Terminal
+#error This example is only available for Arduino Portenta, Arduino Nano RP2040 Connect, ESP32 Dev module and Wio Terminal
 #endif
 
 rcl_publisher_t publisher;

--- a/examples/micro-ros_publisher_wifi/micro-ros_publisher_wifi.ino
+++ b/examples/micro-ros_publisher_wifi/micro-ros_publisher_wifi.ino
@@ -1,23 +1,4 @@
-// If you use "ESP-AT External WiFi module"(hereinafter called "ESP-AT") with your board,
-// Install "WiFiEspAT" from Library Manager and uncomment definition below.
-// See https://www.espressif.com/en/products/sdks/esp-at/overview for more details about ESP-AT.
-// #define USE_WIFI_ESP_AT
-
-#if defined(USE_WIFI_ESP_AT)
-#define BOARD_WITH_ESP_AT
-// Configurations about communication between Host MCU and ESP-AT.
-// In most cases, you would burn ESP-AT firmware v2 or later. And you should uncomment "#define WIFIESPAT1" in EspAtDrvTypes.h
-// See https://github.com/JAndrassy/WiFiEspAT/tree/7f398e14f331fc845c4af671f1946fe3f29a744f#getting-started for more details.
-#define ESP_AT_SERIAL_PORT Serial1 // Serial port object to ESP-AT
-#define ESP_AT_BAUDRATE 115200 // Baudrate setting in ESP-AT firmware(default is 115200)
-#define ESP_AT_RESET_PIN -1 // GPIO_PIN connected to ESP-AT's reset pin(-1 means not to use hardware reset)
-#endif
-
 #include <micro_ros_arduino.h>
-
-#if defined(BOARD_WITH_ESP_AT)
-#include <wifi_transport.cpp>
-#endif
 
 #include <stdio.h>
 #include <rcl/rcl.h>
@@ -27,16 +8,8 @@
 
 #include <std_msgs/msg/int32.h>
 
-#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_WIO_TERMINAL)
-#define BOARD_HAS_NATIVE_WIFI
-#endif
-
-#if !defined(BOARD_HAS_NATIVE_WIFI) && !defined(BOARD_WITH_ESP_AT)
-#error This example is only available for Arduino Portenta, Arduino Nano RP2040 Connect, ESP32 Dev module, Wio Terminal, and other boards with ESP-AT.
-#endif
-
-#if defined(BOARD_HAS_NATIVE_WIFI) && defined(BOARD_WITH_ESP_AT)
-#error USE_WIFI_ESP_AT is not supported on boards that have native WiFi.
+#if !defined(ESP32) && !defined(TARGET_PORTENTA_H7_M7) && !defined(ARDUINO_NANO_RP2040_CONNECT) && !defined(ARDUINO_WIO_TERMINAL)
+#error This example is only avaible for Arduino Portenta, Arduino Nano RP2040 Connect, ESP32 Dev module and Wio Terminal
 #endif
 
 rcl_publisher_t publisher;

--- a/examples/micro-ros_publisher_wifi/micro-ros_publisher_wifi.ino
+++ b/examples/micro-ros_publisher_wifi/micro-ros_publisher_wifi.ino
@@ -1,4 +1,23 @@
+// If you use "ESP-AT External WiFi module"(hereinafter called "ESP-AT") with your board,
+// Install "WiFiEspAT" from Library Manager and uncomment definition below.
+// See https://www.espressif.com/en/products/sdks/esp-at/overview for more details about ESP-AT.
+// #define USE_WIFI_ESP_AT
+
+#if defined(USE_WIFI_ESP_AT)
+#define BOARD_WITH_ESP_AT
+// Configurations about communication between Host MCU and ESP-AT.
+// In most cases, you would burn ESP-AT firmware v2 or later. And you should uncomment "#define WIFIESPAT1" in EspAtDrvTypes.h
+// See https://github.com/JAndrassy/WiFiEspAT/tree/7f398e14f331fc845c4af671f1946fe3f29a744f#getting-started for more details.
+#define ESP_AT_SERIAL_PORT Serial1 // Serial port object to ESP-AT
+#define ESP_AT_BAUDRATE 115200 // Baudrate setting in ESP-AT firmware(default is 115200)
+#define ESP_AT_RESET_PIN -1 // GPIO_PIN connected to ESP-AT's reset pin(-1 means not to use hardware reset)
+#endif
+
 #include <micro_ros_arduino.h>
+
+#if defined(BOARD_WITH_ESP_AT)
+#include <wifi_transport.cpp>
+#endif
 
 #include <stdio.h>
 #include <rcl/rcl.h>
@@ -8,8 +27,16 @@
 
 #include <std_msgs/msg/int32.h>
 
-#if !defined(ESP32) && !defined(TARGET_PORTENTA_H7_M7) && !defined(ARDUINO_NANO_RP2040_CONNECT) && !defined(ARDUINO_WIO_TERMINAL)
-#error This example is only avaible for Arduino Portenta, Arduino Nano RP2040 Connect, ESP32 Dev module and Wio Terminal
+#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_WIO_TERMINAL)
+#define BOARD_HAS_NATIVE_WIFI
+#endif
+
+#if !defined(BOARD_HAS_NATIVE_WIFI) && !defined(BOARD_WITH_ESP_AT)
+#error This example is only available for Arduino Portenta, Arduino Nano RP2040 Connect, ESP32 Dev module, Wio Terminal, and other boards with ESP-AT.
+#endif
+
+#if defined(BOARD_HAS_NATIVE_WIFI) && defined(BOARD_WITH_ESP_AT)
+#error USE_WIFI_ESP_AT is not supported on boards that have native WiFi.
 #endif
 
 rcl_publisher_t publisher;

--- a/examples/micro-ros_publisher_wifi_at/micro-ros_publisher_wifi_at.ino
+++ b/examples/micro-ros_publisher_wifi_at/micro-ros_publisher_wifi_at.ino
@@ -1,0 +1,89 @@
+// To use "ESP-AT External WiFi module"(hereinafter called "ESP-AT") with your board, install "WiFiEspAT" from Library Manager.
+// See https://www.espressif.com/en/products/sdks/esp-at/overview for more details about ESP-AT.
+
+#define BOARD_WITH_ESP_AT
+// Configurations about communication between Host MCU and ESP-AT.
+// In most cases, you would burn ESP-AT firmware v2 or later. And you should uncomment "#define WIFIESPAT1" in EspAtDrvTypes.h
+// See https://github.com/JAndrassy/WiFiEspAT/tree/7f398e14f331fc845c4af671f1946fe3f29a744f#getting-started for more details.
+#define ESP_AT_SERIAL_PORT Serial1 // Serial port object to ESP-AT
+#define ESP_AT_BAUDRATE 115200 // Baudrate setting in ESP-AT firmware(default is 115200)
+#define ESP_AT_RESET_PIN -1 // GPIO_PIN connected to ESP-AT's reset pin(-1 means not to use hardware reset)
+
+#include <micro_ros_arduino.h>
+
+#include <wifi_transport.cpp>
+
+#include <stdio.h>
+#include <rcl/rcl.h>
+#include <rcl/error_handling.h>
+#include <rclc/rclc.h>
+#include <rclc/executor.h>
+
+#include <std_msgs/msg/int32.h>
+
+#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_WIO_TERMINAL)
+#define BOARD_HAS_NATIVE_WIFI
+#endif
+
+#if defined(BOARD_HAS_NATIVE_WIFI)
+#error This example is not available for boards that have native WiFi.
+#endif
+
+rcl_publisher_t publisher;
+std_msgs__msg__Int32 msg;
+rclc_support_t support;
+rcl_allocator_t allocator;
+rcl_node_t node;
+
+#define LED_PIN 13
+
+#define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){error_loop();}}
+#define RCSOFTCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){}}
+
+
+void error_loop(){
+  while(1){
+    digitalWrite(LED_PIN, !digitalRead(LED_PIN));
+    delay(100);
+  }
+}
+
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+{
+  RCLC_UNUSED(last_call_time);
+  if (timer != NULL) {
+    RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));
+    msg.data++;
+  }
+}
+
+void setup() {
+  set_microros_wifi_transports("WIFI SSID", "WIFI PASS", "192.168.1.57", 8888);
+
+  pinMode(LED_PIN, OUTPUT);
+  digitalWrite(LED_PIN, HIGH);
+
+  delay(2000);
+
+  allocator = rcl_get_default_allocator();
+
+  //create init_options
+  RCCHECK(rclc_support_init(&support, 0, NULL, &allocator));
+
+  // create node
+  RCCHECK(rclc_node_init_default(&node, "micro_ros_arduino_wifi_node", "", &support));
+
+  // create publisher
+  RCCHECK(rclc_publisher_init_best_effort(
+    &publisher,
+    &node,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32),
+    "topic_name"));
+
+  msg.data = 0;
+}
+
+void loop() {
+    RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));
+    msg.data++;
+}

--- a/src/micro_ros_arduino.h
+++ b/src/micro_ros_arduino.h
@@ -95,7 +95,7 @@ static inline void set_microros_native_ethernet_udp_transports(byte mac[], IPAdd
 
 #endif
 
-#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_WIO_TERMINAL)
+#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_WIO_TERMINAL) || defined(BOARD_WITH_ESP_AT)
 
 #if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7)
 #include <WiFi.h>
@@ -106,6 +106,8 @@ static inline void set_microros_native_ethernet_udp_transports(byte mac[], IPAdd
 #elif defined(ARDUINO_WIO_TERMINAL)
 #include <rpcWiFi.h>
 #include <WiFiUdp.h>
+#elif defined(BOARD_WITH_ESP_AT)
+#include <WiFiEspAT.h>
 #endif
 
 extern "C" bool arduino_wifi_transport_open(struct uxrCustomTransport * transport);
@@ -120,6 +122,15 @@ struct micro_ros_agent_locator {
 #endif
 
 static inline void set_microros_wifi_transports(char * ssid, char * pass, char * agent_ip, uint agent_port){
+
+	#if defined(BOARD_WITH_ESP_AT)
+	ESP_AT_SERIAL_PORT.begin(ESP_AT_BAUDRATE);
+	while (!ESP_AT_SERIAL_PORT) {
+	}
+	WiFi.init(ESP_AT_SERIAL_PORT, ESP_AT_RESET_PIN);
+	while (WiFi.status() == WL_NO_MODULE) {
+	}
+	#endif
 
 	WiFi.begin(ssid, pass);
 

--- a/src/wifi_transport.cpp
+++ b/src/wifi_transport.cpp
@@ -1,4 +1,4 @@
-#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_WIO_TERMINAL)
+#if defined(ESP32) || defined(TARGET_PORTENTA_H7_M7) || defined(ARDUINO_NANO_RP2040_CONNECT) || defined(ARDUINO_WIO_TERMINAL) || defined(BOARD_WITH_ESP_AT)
 #include <Arduino.h>
 
 
@@ -11,6 +11,8 @@
 #elif defined(ARDUINO_WIO_TERMINAL)
 #include <rpcWiFi.h>
 #include <WiFiUdp.h>
+#elif defined(BOARD_WITH_ESP_AT)
+#include <WiFiEspAT.h>
 #endif
 
 #include <micro_ros_arduino.h>


### PR DESCRIPTION
# What I changed

- Enable to compile `micro-ros_publisher_wifi` example in the following cases.
  - WiFiEspAT library is installed.
  - "USE_WIFI_ESP_AT" macro is defined at head of sketch.
- Update CI for build example test.
- Add section to describe about WiFiEspAT in README.md

# What I tested

- Run CI successfully in my forked repository.
- Build `micro-ros_publisher_wifi` example for boards below and Run  successfully.

`Raspberry Pi Pico`

https://github.com/micro-ROS/micro_ros_arduino/assets/61191940/5971e90c-17be-4dff-98ee-f8d5fc6be331

`Seeed Studio XIAO SAMD21`

https://github.com/micro-ROS/micro_ros_arduino/assets/61191940/2db935bc-e53e-4019-81b5-4db61cce0c12

`Seeed Studio XIAO RP2040`

https://github.com/micro-ROS/micro_ros_arduino/assets/61191940/45b62fe0-7d86-4403-9ea1-f874b41292e9
