### PR TITLE
Bump CI runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
 jobs:
 
     micro_ros_arduino:
-        runs-on: ubuntu-20.04
-        container: ubuntu:20.04
+        runs-on: ubuntu-22.04
+        container: ubuntu:22.04
 
         steps:
         - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 runner has been deprecated by GitHub.